### PR TITLE
[Refactor VII] Add IP to region codes

### DIFF
--- a/src/s3_log_extraction/ip_utils/_ip_utils.py
+++ b/src/s3_log_extraction/ip_utils/_ip_utils.py
@@ -1,12 +1,77 @@
 import functools
 
+import requests
+
 
 @functools.lru_cache
 def _request_cidr_range(service_name: str) -> dict:
     """Cache (in-memory) the requests to external services."""
-    pass
+    match service_name:
+        case "GitHub":
+            github_cidr_request = requests.get(url="https://api.github.com/meta").json()
+
+            return github_cidr_request
+        case "AWS":
+            aws_cidr_request = requests.get(url="https://ip-ranges.amazonaws.com/ip-ranges.json").json()
+
+            return aws_cidr_request
+        case "GCP":
+            gcp_cidr_request = requests.get(url="https://www.gstatic.com/ipranges/cloud.json").json()
+
+            return gcp_cidr_request
+        case "Azure":
+            raise NotImplementedError("Azure CIDR address fetching is not yet implemented!")
+        case "VPN":
+            # Very nice public and maintained listing! Hope this stays stable.
+            vpn_cidr_request = (
+                requests.get(
+                    url="https://raw.githubusercontent.com/josephrocca/is-vpn/main/vpn-or-datacenter-ipv4-ranges.txt"
+                )
+                .content.decode("utf-8")
+                .splitlines()
+            )
+
+            return vpn_cidr_request
+        case _:
+            raise ValueError(f"Service name '{service_name}' is not supported!")  # pragma: no cover
 
 
 @functools.lru_cache
 def _get_cidr_address_ranges_and_subregions(*, service_name: str) -> list[tuple[str, str | None]]:
-    pass
+    cidr_request = _request_cidr_range(service_name=service_name)
+    match service_name:
+        case "GitHub":
+            skip_keys = ["domains", "ssh_key_fingerprints", "verifiable_password_authentication", "ssh_keys"]
+            keys = set(cidr_request.keys()) - set(skip_keys)
+            github_cidr_addresses_and_subregions = [
+                (cidr_address, None)
+                for key in keys
+                for cidr_address in cidr_request[key]
+                if "::" not in cidr_address
+                # Skip IPv6
+            ]
+
+            return github_cidr_addresses_and_subregions
+        # Note: these endpoints also return the 'locations' of the specific subnet, such as 'us-east-2'
+        case "AWS":
+            aws_cidr_addresses_and_subregions = [
+                (prefix["ip_prefix"], prefix.get("region", None)) for prefix in cidr_request["prefixes"]
+            ]
+
+            return aws_cidr_addresses_and_subregions
+        case "GCP":
+            gcp_cidr_addresses_and_subregions = [
+                (prefix["ipv4Prefix"], prefix.get("scope", None))
+                for prefix in cidr_request["prefixes"]
+                if "ipv4Prefix" in prefix  # Not handling IPv6 yet
+            ]
+
+            return gcp_cidr_addresses_and_subregions
+        case "Azure":
+            raise NotImplementedError("Azure CIDR address fetching is not yet implemented!")  # pragma: no cover
+        case "VPN":
+            vpn_cidr_addresses_and_subregions = [(cidr_address, None) for cidr_address in cidr_request]
+
+            return vpn_cidr_addresses_and_subregions
+        case _:
+            raise ValueError(f"Service name '{service_name}' is not supported!")  # pragma: no cover

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -1,11 +1,93 @@
+import ipaddress
+import os
+
 import ipinfo
+import yaml
+
+from ._globals import _KNOWN_SERVICES
+from ._ip_cache import get_ip_cache_directory, load_index_to_ip, load_ip_cache
+from ._ip_utils import _get_cidr_address_ranges_and_subregions
 
 
 def update_index_to_region_codes() -> str | None:
-    pass
+    """Update the `indexed_region_codes.yaml` file in the cache directory."""
+    ipinfo_api_key = os.environ.get("IPINFO_API_KEY", None)
+    if ipinfo_api_key is None:
+        message = "The environment variable 'IPINFO_API_KEY' must be set to import `s3_log_extraction`!"
+        raise ValueError(message)  # pragma: no cover
+    ipinfo_handler = ipinfo.getHandler(access_token=ipinfo_api_key)
+
+    ip_cache_directory = get_ip_cache_directory()
+    index_not_in_services = load_ip_cache(cache_type="index_not_in_services")
+
+    index_to_ip = load_index_to_ip()
+    index_to_region = load_ip_cache(cache_type="index_to_region")
+    indices_to_update = set(index_to_ip.keys()) - set(index_to_region.keys())
+    for ip_index in indices_to_update:
+        ip_address = index_to_ip[ip_index]
+        region_code = _get_region_code_from_ip_index(
+            ip_index=ip_index,
+            ip_address=ip_address,
+            ipinfo_handler=ipinfo_handler,
+            index_not_in_services=index_not_in_services,
+        )
+
+        # API limit reached; do not cache and wait for it to reset
+        if region_code == "TBD":
+            continue
+        index_to_region[ip_index] = region_code
+
+    indexed_regions_file_path = ip_cache_directory / "index_to_region.yaml"
+    with indexed_regions_file_path.open(mode="w") as file_stream:
+        yaml.dump(data=index_to_region, stream=file_stream)
 
 
 def _get_region_code_from_ip_index(
     ip_index: int, ip_address: str, ipinfo_handler: ipinfo.Handler, index_not_in_services: dict[int, bool]
 ) -> str:
-    pass
+    # Determine if IP address belongs to GitHub, AWS, Google, or known VPNs
+    # Azure not yet easily doable; keep an eye on
+    # https://learn.microsoft.com/en-us/answers/questions/1410071/up-to-date-azure-public-api-to-get-azure-ip-ranges
+    # maybe it will change in the future
+    if index_not_in_services.get(ip_index, None) is None:
+        for service_name in _KNOWN_SERVICES:
+            cidr_addresses_and_subregions = _get_cidr_address_ranges_and_subregions(service_name=service_name)
+
+            matched_cidr_address_and_subregion = next(
+                (
+                    (cidr_address, subregion)
+                    for cidr_address, subregion in cidr_addresses_and_subregions
+                    if ipaddress.ip_address(address=ip_address) in ipaddress.ip_network(address=cidr_address)
+                ),
+                None,
+            )
+            if matched_cidr_address_and_subregion is not None:
+                region_service_string = service_name
+
+                subregion = matched_cidr_address_and_subregion[1]
+                if subregion is not None:
+                    region_service_string += f"/{subregion}"
+                return region_service_string
+    index_not_in_services[ip_index] = True
+
+    # Lines cannot be covered without testing on a real IP
+    try:  # pragma: no cover
+        details = ipinfo_handler.getDetails(ip_address=ip_address)
+
+        country = details.details.get("country", None)
+        region = details.details.get("region", None)
+
+        region_string = ""  # Not technically necessary, but quiets the linter
+        match (country is None, region is None):
+            case (True, True):
+                region_string = "unknown"
+            case (True, False):
+                region_string = region
+            case (False, True):
+                region_string = country
+            case (False, False):
+                region_string = f"{country}/{region}"
+
+        return region_string
+    except ipinfo.exceptions.RequestQuotaExceededError:  # pragma: no cover
+        return "TBD"


### PR DESCRIPTION
This PR adds region detection for each IP that requested data

Regions are either some string reference to a cloud service (such as "GitHub" or "VPN") or data centers ("AWS/us-east-2", "GCP/us-central1", etc.) or an ISO 3166 country code with region name (such as "US/California")

