### PR TITLE
Define different Python environments conveniently managed by Hatch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
         exclude: ^docs/
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.3
+  rev: v0.12.4
   hooks:
   - id: ruff
     args: [ --fix ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ all = [
     {include-group = "dev"}
 ]
 
+[tool.hatch.envs.default]
+features = ["all"]
+
 [tool.hatch.envs.test]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,13 @@ features = ["all"]
 #  details.
 post-install-commands = ["pip install --group dev"]
 
+[tool.hatch.envs.all]
+features = ["all"]
+#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
+#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
+#  details.
+post-install-commands = ["pip install --group all"]
+
 [tool.black]
 line-length = 120
 target-version = ['py312']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,23 @@ all = [
     {include-group = "dev"}
 ]
 
+[tool.hatch.envs.test]
+#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
+#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
+#  details.
+post-install-commands = ["pip install --group test"]
 
+[tool.hatch.envs.coverage]
+#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
+#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
+#  details.
+post-install-commands = ["pip install --group coverage"]
+
+[tool.hatch.envs.dev]
+#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
+#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
+#  details.
+post-install-commands = ["pip install --group dev"]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,30 @@ source = "vcs"
 [tool.hatch.build.targets.wheel]
 packages = ["src/s3_log_extraction"]
 
+# This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
+#   in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
+#   details.
+#
+# Execute `hatch env create test` to create the environment
+# Execute `hatch run test:pytest tests` to run tests in the hatch environment
+[tool.hatch.envs.test]
+features = ["all"]
+post-install-commands = ["pip install --group test"]
+
+[tool.hatch.envs.coverage]
+templates = "test"  # Set this environment to inherit from the test environment
+post-install-commands = ["pip install --group coverage"]
+
+[tool.hatch.envs.dev]
+features = ["all"]
+post-install-commands = ["pip install --group dev"]
+
+[tool.hatch.envs.all]
+features = ["all"]
+post-install-commands = ["pip install --group all"]
+
+
+
 [project]
 name = "s3-log-extraction"
 version="1.1.2"
@@ -85,33 +109,7 @@ all = [
     {include-group = "dev"}
 ]
 
-[tool.hatch.envs.test]
-features = ["all"]
-#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
-#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
-#  details.
-post-install-commands = ["pip install --group test"]
 
-[tool.hatch.envs.coverage]
-templates = "test"  # Set this environment to inherit from the test environment
-#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
-#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
-#  details.
-post-install-commands = ["pip install --group coverage"]
-
-[tool.hatch.envs.dev]
-features = ["all"]
-#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
-#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
-#  details.
-post-install-commands = ["pip install --group dev"]
-
-[tool.hatch.envs.all]
-features = ["all"]
-#This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
-#  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
-#  details.
-post-install-commands = ["pip install --group all"]
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,25 +85,25 @@ all = [
     {include-group = "dev"}
 ]
 
-[tool.hatch.envs.default]
-features = ["all"]
-
 [tool.hatch.envs.test]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
+features = ["all"]
 post-install-commands = ["pip install --group test"]
 
 [tool.hatch.envs.coverage]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
+templates = "test"  # Set this environment to inherit from the test environment
 post-install-commands = ["pip install --group coverage"]
 
 [tool.hatch.envs.dev]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
+features = ["all"]
 post-install-commands = ["pip install --group dev"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,24 +86,24 @@ all = [
 ]
 
 [tool.hatch.envs.test]
+features = ["all"]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
-features = ["all"]
 post-install-commands = ["pip install --group test"]
 
 [tool.hatch.envs.coverage]
+templates = "test"  # Set this environment to inherit from the test environment
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
-templates = "test"  # Set this environment to inherit from the test environment
 post-install-commands = ["pip install --group coverage"]
 
 [tool.hatch.envs.dev]
+features = ["all"]
 #This is a temporary hack while waiting for hatch to support PEP 735, Dependency Groups,
 #  in creating environments. See https://github.com/pypa/hatch/pull/1922 for more
 #  details.
-features = ["all"]
 post-install-commands = ["pip install --group dev"]
 
 [tool.black]


### PR DESCRIPTION
This PR define environments that are conveniently managed by Hatch. These environments are mapped directly from the dependency groups in `pyproject.toml`.

This PR closes #100.
