### PR TITLE
Deduplicate blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 # Upcoming
 
+## Features
+
 Added `s3_log_extraction.extractors.RemoteS3LogAccessExtractor` class for running extraction remotely rather than on local files.
  - Also includes the `s3_log_extraction.extractors.DandiRemoteS3LogAccessExtractor` class for DANDI-specific options.
 
 Added parallelization option for UNIX systems, with all but one CPU requested by default.
+
+# Improvements
+
+Added `bogon` labeling for IP addresses that are not routable on the public internet, such as private IPs and reserved ranges. This improves the update iteration of the `s3logextraction update ip regions`.
+
+## Fixes
+
+Fixed an issue related to duplication of access activity for assets that are duplicated (with multiple associated asset paths) within a Dandiset. Summary reports for DANDI prior to 7/27/2025 over count due to this issue.
+
+Fixed the running of `s3logextraction update summaries --mode dandi` when running without `skip` or `pick` options.
 
 
 

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -243,15 +243,29 @@ def _update_ip_coordinates_cli() -> None:
     type=click.STRING,
     default=None,
 )
+@click.option(
+    "--workers",
+    help=(
+        "The maximum number of workers to use for parallel processing. "
+        "Allows negative slicing semantics, where -1 means all available cores, -2 means all but one, etc. "
+        "By default, "
+    ),
+    required=False,
+    type=click.IntRange(min=-os.cpu_count() + 1, max=os.cpu_count()),
+    default=-2,
+)
 def _update_summaries_cli(
-    mode: typing.Literal["dandi", "archive"] | None = None, pick: str | None = None, skip: str | None = None
+    mode: typing.Literal["dandi", "archive"] | None = None,
+    pick: str | None = None,
+    skip: str | None = None,
+    workers: int = -2,
 ) -> None:
     """Generate condensed summaries of activity."""
     match mode:
         case "dandi":
             pick_as_list = pick.split(",") if pick is not None else None
             skip_as_list = skip.split(",") if skip is not None else None
-            generate_dandiset_summaries(pick=pick_as_list, skip=skip_as_list)
+            generate_dandiset_summaries(pick=pick_as_list, skip=skip_as_list, workers=workers)
         case "archive":
             generate_archive_summaries()
         case _:

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -8,8 +8,9 @@ import tqdm
 import yaml
 
 from ._globals import _KNOWN_SERVICES
-from ._ip_cache import get_ip_cache_directory, load_index_to_ip, load_ip_cache
+from ._ip_cache import load_index_to_ip, load_ip_cache
 from ._ip_utils import _get_cidr_address_ranges_and_subregions
+from ..config import get_ip_cache_directory
 
 
 def update_index_to_region_codes(batch_size: int = 1_000) -> str | None:

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -104,6 +104,8 @@ def _get_region_code_from_ip_index(
         country = details.details.get("country", None)
         region = details.details.get("region", None)
 
+        print(f"\n\n{details=}\n\n")
+
         match (country is None, region is None):
             case (True, True):
                 region_string = None

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -104,11 +104,6 @@ def _get_region_code_from_ip_index(
         country = details.details.get("country", None)
         region = details.details.get("region", None)
 
-        print(f"\n\n{details.details=}\n\n")
-        is_bogon = details.details.get("bogon", False)
-        print(f"\n\n{is_bogon=}\n\n")
-        raise NotImplementedError("")
-
         match (country is None, region is None):
             case (True, True):
                 region_string = "bogon" if details.details.get("bogon", False) is True else None

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -104,7 +104,7 @@ def _get_region_code_from_ip_index(
         country = details.details.get("country", None)
         region = details.details.get("region", None)
 
-        print(f"\n\n{details=}\n\n")
+        print(f"\n\n{details.__dict__=}\n\n")
         raise NotImplementedError("")
 
         match (country is None, region is None):

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -104,12 +104,14 @@ def _get_region_code_from_ip_index(
         country = details.details.get("country", None)
         region = details.details.get("region", None)
 
-        print(f"\n\n{details.__dict__=}\n\n")
+        print(f"\n\n{details.details=}\n\n")
+        is_bogon = details.details.get("bogon", False)
+        print(f"\n\n{is_bogon=}\n\n")
         raise NotImplementedError("")
 
         match (country is None, region is None):
             case (True, True):
-                region_string = None
+                region_string = "bogon" if details.details.get("bogon", False) is True else None
             case (True, False):
                 region_string = region
             case (False, True):

--- a/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_index_to_region_codes.py
@@ -105,6 +105,7 @@ def _get_region_code_from_ip_index(
         region = details.details.get("region", None)
 
         print(f"\n\n{details=}\n\n")
+        raise NotImplementedError("")
 
         match (country is None, region is None):
             case (True, True):

--- a/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
+++ b/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
@@ -52,15 +52,17 @@ def generate_dandiset_summaries(
 
     # TODO: cache even the dandiset listing and leverage etags
     client = dandi.dandiapi.DandiAPIClient()
-    if pick is None:
+    if pick is None and skip is not None:
         dandiset_ids_to_exclude = {dandiset_id: True for dandiset_id in skip}
         dandiset_ids_to_summarize = [
             dandiset.identifier
             for dandiset in client.get_dandisets()
             if dandiset_ids_to_exclude.get(dandiset.identifier, False) is False
         ]
-    else:
+    elif pick is not None and skip is None:
         dandiset_ids_to_summarize = pick
+    else:
+        dandiset_ids_to_summarize = [dandiset.identifier for dandiset in client.get_dandisets()]
 
     if max_workers == 1:
         for dandiset_id in tqdm.tqdm(

--- a/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
+++ b/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
@@ -287,17 +287,15 @@ def _summarize_dandiset_by_asset(
 ) -> None:
     summarized_activity_by_asset = collections.defaultdict(int)
     for blob_directory in blob_directories:
-        # TODO: Could add a step here to track which object IDs have been processed, and if encountered again
-        # Just copy the file over instead of reprocessing
+        blob_id = blob_directory.name
 
-        if not blob_directory.exists():
-            continue  # No extracted logs found (possible asset was never accessed); skip to next asset
+        # It is possible that this blob cannot be uniquely associated with an asset path within the Dandiset
+        # (the blob ID would not be in the asset path mapping in that case)
+        asset_path = blob_id_to_asset_path.get(blob_id, "undetermined")
 
         bytes_sent_file_path = blob_directory / "bytes_sent.txt"
         bytes_sent = [int(value.strip()) for value in bytes_sent_file_path.read_text().splitlines()]
 
-        blob_id = blob_directory.name
-        asset_path = blob_id_to_asset_path[blob_id]
         summarized_activity_by_asset[asset_path] += sum(bytes_sent)
 
     if len(summarized_activity_by_asset) == 0:

--- a/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
+++ b/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
@@ -77,7 +77,7 @@ def generate_dandiset_summaries(
 
             _summarize_dandiset(
                 dandiset_id=dandiset_id,
-                asset_directories=asset_directories,
+                blob_directories=asset_directories,
                 summary_directory=summary_directory,
                 index_to_region=index_to_region,
                 blob_id_to_asset_path=blob_id_to_asset_path,
@@ -116,7 +116,7 @@ def generate_dandiset_summaries(
     dandiset_id = "undetermined"
     _summarize_dandiset(
         dandiset_id=dandiset_id,
-        asset_directories=dandiset_id_to_asset_directories.get(dandiset_id, []),
+        blob_directories=dandiset_id_to_asset_directories.get(dandiset_id, []),
         summary_directory=summary_directory,
         index_to_region=index_to_region,
         blob_id_to_asset_path=blob_id_to_asset_path,
@@ -133,109 +133,126 @@ def _get_dandi_asset_info(
     extraction_directory = get_extraction_directory()
 
     date = datetime.datetime.now().date().strftime("%Y_%m")
-    monthly_dandiset_id_to_asset_directories_cache_file_path = (
-        dandi_cache_directory / f"dandiset_id_to_asset_directories_{date}.yaml"
+    monthly_dandiset_id_to_blob_directories_cache_file_path = (
+        dandi_cache_directory / f"dandiset_id_to_blob_directories_{date}.yaml"
     )
     monthly_blob_id_to_asset_path_cache_file_path = dandi_cache_directory / f"blob_id_to_asset_path_{date}.yaml"
     if use_cache is True and monthly_blob_id_to_asset_path_cache_file_path.exists():
-        with monthly_dandiset_id_to_asset_directories_cache_file_path.open(mode="r") as file_stream:
+        with monthly_dandiset_id_to_blob_directories_cache_file_path.open(mode="r") as file_stream:
             yaml_content = yaml.safe_load(stream=file_stream)
 
-        dandiset_id_to_asset_directories = {
-            dandiset_id: [pathlib.Path(asset_directory) for asset_directory in asset_directories]
-            for dandiset_id, asset_directories in yaml_content.items()
+        dandiset_id_to_blob_directories = {
+            dandiset_id: [pathlib.Path(blob_directory) for blob_directory in blob_directories]
+            for dandiset_id, blob_directories in yaml_content.items()
         }
 
         with monthly_blob_id_to_asset_path_cache_file_path.open(mode="r") as file_stream:
             blob_id_to_asset_path = yaml.safe_load(stream=file_stream)
     else:
         client = dandi.dandiapi.DandiAPIClient()
-
-        asset_id_to_asset = dict()
-        blob_id_to_asset_path = dict()
-        asset_id_to_dandiset_ids = collections.defaultdict(set)
         dandisets = list(client.get_dandisets())
+
+        blob_id_to_associated_asset_paths: dict[str, set[str]] = collections.defaultdict(set)
+        blob_directory_to_associated_dandiset_ids: dict[str, set[str]] = collections.defaultdict(set)
         for base_dandiset in tqdm.tqdm(
-            iterable=dandisets, total=len(dandisets), desc="Updating asset caches", unit="dandisets", smoothing=0
+            iterable=dandisets,
+            total=len(dandisets),
+            desc="Mapping blob IDs to Dandisets",
+            unit="dandisets",
+            smoothing=0,
         ):
+            dandiset_id = base_dandiset.identifier
+
             for version in base_dandiset.get_versions():
-                dandiset = client.get_dandiset(dandiset_id=base_dandiset.identifier, version_id=version.identifier)
-                for asset in dandiset.get_assets():
-                    asset_id_to_asset[asset.identifier] = asset
+                versioned_dandiset = client.get_dandiset(
+                    dandiset_id=base_dandiset.identifier, version_id=version.identifier
+                )
+                for asset in versioned_dandiset.get_assets():
                     blob_id = asset.zarr if ".zarr" in pathlib.Path(asset.path).suffixes else asset.blob
-                    blob_id_to_asset_path[blob_id] = asset.path
-                    asset_id_to_dandiset_ids[asset.identifier].update({dandiset.identifier})
-                    # ID must be an iterable to maintain entire string
+                    blob_id_to_associated_asset_paths[blob_id].add(asset.path)
 
-        dandiset_id_to_asset_directories = collections.defaultdict(list)
-        for asset_id, dandiset_ids in asset_id_to_dandiset_ids.items():
-            asset = asset_id_to_asset[asset_id]
-            asset_directory = (
-                extraction_directory / "zarr" / asset.zarr
-                if ".zarr" in pathlib.Path(asset.path).suffixes
-                else extraction_directory / "blobs" / asset.blob[:3] / asset.blob[3:6] / asset.blob
-            )
+                    blob_directory = (
+                        extraction_directory / "zarr" / blob_id
+                        if ".zarr" in pathlib.Path(asset.path).suffixes
+                        else extraction_directory / "blobs" / blob_id[:3] / blob_id[3:6] / blob_id
+                    )
+                    blob_directory_to_associated_dandiset_ids[blob_directory].add(dandiset_id)
 
+        blob_id_to_asset_path = dict()
+        dandiset_id_to_blob_directories = collections.defaultdict(list)
+        for blob_directory, dandiset_ids in blob_directory_to_associated_dandiset_ids.items():
+            blob_id = blob_directory.name
+
+            # Case 1: multiple Dandisets linked to the same blob ID
+            # Cannot uniquely associate activity to a particular Dandiset, so mark Dandiset ID as undetermined
             if len(dandiset_ids) > 1:
-                dandiset_id_to_asset_directories["undetermined"].append(asset_directory)
-            else:
-                dandiset_id = next(iter(dandiset_ids))
-                dandiset_id_to_asset_directories[dandiset_id].append(asset_directory)
+                dandiset_id_to_blob_directories["undetermined"].append(blob_directory)
+                continue
+            dandiset_id = next(iter(dandiset_ids))
+            dandiset_id_to_blob_directories[dandiset_id].append(blob_directory)
+
+            # Case 2: multiple assets linked to the same blob ID within a single Dandiset (including across versions)
+            # Able to uniquely associate activity to a particular Dandiset
+            # But may not be able to uniquely associate activity to a particular asset path
+            associated_asset_paths = blob_id_to_associated_asset_paths[blob_id]
+            if len(associated_asset_paths) > 1:
+                continue
+            blob_id_to_asset_path[blob_id] = next(iter(associated_asset_paths))
 
         yaml_content = {
-            dandiset_id: [str(asset_directory) for asset_directory in asset_directories]
-            for dandiset_id, asset_directories in dandiset_id_to_asset_directories.items()
+            dandiset_id: [str(blob_directory) for blob_directory in blob_directories]
+            for dandiset_id, blob_directories in dandiset_id_to_blob_directories.items()
         }
-        with monthly_dandiset_id_to_asset_directories_cache_file_path.open(mode="w") as file_stream:
+        with monthly_dandiset_id_to_blob_directories_cache_file_path.open(mode="w") as file_stream:
             yaml.dump(data=yaml_content, stream=file_stream)
 
         with monthly_blob_id_to_asset_path_cache_file_path.open(mode="w") as file_stream:
             yaml.dump(data=blob_id_to_asset_path, stream=file_stream)
 
-    return dandiset_id_to_asset_directories, blob_id_to_asset_path
+    return dandiset_id_to_blob_directories, blob_id_to_asset_path
 
 
 def _summarize_dandiset(
     *,
     dandiset_id: str,
-    asset_directories: list[pathlib.Path],
+    blob_directories: list[pathlib.Path],
     summary_directory: pathlib.Path,
     index_to_region: dict[int, str],
     blob_id_to_asset_path: dict[str, str],
 ) -> None:
     _summarize_dandiset_by_day(
-        asset_directories=asset_directories, summary_file_path=summary_directory / dandiset_id / "by_day.tsv"
+        blob_directories=blob_directories, summary_file_path=summary_directory / dandiset_id / "by_day.tsv"
     )
     _summarize_dandiset_by_asset(
-        asset_directories=asset_directories,
+        asset_directories=blob_directories,
         summary_file_path=summary_directory / dandiset_id / "by_asset.tsv",
         blob_id_to_asset_path=blob_id_to_asset_path,
     )
     _summarize_dandiset_by_region(
-        asset_directories=asset_directories,
+        asset_directories=blob_directories,
         summary_file_path=summary_directory / dandiset_id / "by_region.tsv",
         index_to_region=index_to_region,
     )
 
 
-def _summarize_dandiset_by_day(*, asset_directories: list[pathlib.Path], summary_file_path: pathlib.Path) -> None:
+def _summarize_dandiset_by_day(*, blob_directories: list[pathlib.Path], summary_file_path: pathlib.Path) -> None:
     all_dates = []
     all_bytes_sent = []
-    for asset_directory in asset_directories:
+    for blob_directory in blob_directories:
         # TODO: Could add a step here to track which object IDs have been processed, and if encountered again
         # Just copy the file over instead of reprocessing
 
-        if not asset_directory.exists():
+        if not blob_directory.exists():
             continue  # No extracted logs found (possible asset was never accessed); skip to next asset
 
-        timestamps_file_path = asset_directory / "timestamps.txt"
+        timestamps_file_path = blob_directory / "timestamps.txt"
         dates = [
             _timestamp_to_date_format(timestamp=timestamp)
             for timestamp in timestamps_file_path.read_text().splitlines()
         ]
         all_dates.extend(dates)
 
-        bytes_sent_file_path = asset_directory / "bytes_sent.txt"
+        bytes_sent_file_path = blob_directory / "bytes_sent.txt"
         bytes_sent = [int(value.strip()) for value in bytes_sent_file_path.read_text().splitlines()]
         all_bytes_sent.extend(bytes_sent)
 

--- a/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
+++ b/src/s3_log_extraction/summarize/_generate_dandiset_summaries.py
@@ -289,6 +289,10 @@ def _summarize_dandiset_by_asset(
     for blob_directory in blob_directories:
         blob_id = blob_directory.name
 
+        # No extracted logs found (possible asset was never accessed); skip to next asset
+        if not blob_directory.exists():
+            continue
+
         # It is possible that this blob cannot be uniquely associated with an asset path within the Dandiset
         # (the blob ID would not be in the asset path mapping in that case)
         asset_path = blob_id_to_asset_path.get(blob_id, "undetermined")


### PR DESCRIPTION
Found some edge cases where assets within a Dandiset were duplicated (with different asset paths)

Previous logic did not account for this