### PR TITLE
Add IP address classification statistics to stats command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.3"
+version="1.10.4"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -553,7 +553,7 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use
     Report log-file inventory stats and IP address classification stats.
 
     Reads a local pre-downloaded AWS S3 Inventory directory and prints the
-    file count and total size in bytes for all objects in the inventory.
+    file count for all objects in the inventory.
     Also loads the IP-to-region cache and summarises how many IP addresses
     fall into each classification category (determined, missing, unknown,
     bogon, VPN, cloud service, GitHub).
@@ -562,10 +562,6 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use
         inventory_directory=pathlib.Path(inventory_directory),
     )
     rich_click.echo(f"File count      : {stats['file_count']}")
-    if stats["total_size_bytes"] is not None:
-        rich_click.echo(f"Total size (B)  : {stats['total_size_bytes']}")
-    else:
-        rich_click.echo("Total size (B)  : N/A (Size column not present in inventory)")
 
     cache_path = pathlib.Path(cache_directory) if cache_directory is not None else None
     ip_stats = get_ip_stats(cache_directory=cache_path, use_encryption=use_encryption)

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -550,20 +550,26 @@ def _validate_cli(
 )
 def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use_encryption: bool = True) -> None:
     """
-    Report log-file inventory stats and IP address classification stats.
+    Report log-file inventory stats, extraction completion, and IP address classification stats.
 
     Reads a local pre-downloaded AWS S3 Inventory directory and prints the
-    file count for all objects in the inventory.
-    Also loads the IP-to-region cache and summarises how many IP addresses
-    fall into each classification category (determined, missing, unknown,
-    bogon, VPN, cloud service, GitHub).
+    file count for all objects in the inventory, the extraction completion
+    percentage, and a breakdown of IP address classification categories
+    (determined, missing, unknown, bogon, VPN, cloud service, GitHub).
     """
-    stats = get_log_bucket_stats(
-        inventory_directory=pathlib.Path(inventory_directory),
-    )
+    inventory_path = pathlib.Path(inventory_directory)
+    cache_path = pathlib.Path(cache_directory) if cache_directory is not None else None
+
+    stats = get_log_bucket_stats(inventory_directory=inventory_path)
     rich_click.echo(f"File count      : {stats['file_count']}")
 
-    cache_path = pathlib.Path(cache_directory) if cache_directory is not None else None
+    completion = get_extraction_completion(
+        inventory_directory=inventory_path,
+        cache_directory=cache_path,
+    )
+    rich_click.echo(f"Processed files : {completion['processed_file_count']}")
+    rich_click.echo(f"Percent complete: {completion['percent_complete']:.2f}%")
+
     ip_stats = get_ip_stats(cache_directory=cache_path, use_encryption=use_encryption)
 
     rich_click.echo("")

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -20,7 +20,7 @@ from ..summarize import (
     generate_summaries,
 )
 from ..testing import generate_benchmark
-from ..utils import get_extraction_completion, get_log_bucket_stats
+from ..utils import get_extraction_completion, get_ip_stats, get_log_bucket_stats
 from ..validate import (
     DownloadsLogicPreValidator,
     ExtractionHeuristicPreValidator,
@@ -515,7 +515,7 @@ def _validate_cli(
             validator.validate_directory(directory=directory)
 
 
-# s3logextraction stats --inventory <path>
+# s3logextraction stats --inventory <path> [--cache <path>]
 @s3logextraction_cli.command(name="stats")
 @rich_click.option(
     "--inventory",
@@ -530,12 +530,26 @@ def _validate_cli(
     required=True,
     type=rich_click.Path(exists=True, file_okay=False, dir_okay=True),
 )
-def _stats_cli(inventory_directory: str) -> None:
+@rich_click.option(
+    "--cache",
+    "cache_directory",
+    help=(
+        "Optional cache directory containing IP-to-region lookup records. "
+        "If omitted, uses the configured default cache directory."
+    ),
+    required=False,
+    type=rich_click.Path(exists=True, file_okay=False, dir_okay=True),
+    default=None,
+)
+def _stats_cli(inventory_directory: str, cache_directory: str | None = None) -> None:
     """
-    Report the number of log files and total size recorded in the inventory.
+    Report log-file inventory stats and IP address classification stats.
 
     Reads a local pre-downloaded AWS S3 Inventory directory and prints the
     file count and total size in bytes for all objects in the inventory.
+    Also loads the IP-to-region cache and summarises how many IP addresses
+    fall into each classification category (determined, missing, unknown,
+    bogon, VPN, cloud service, GitHub).
     """
     stats = get_log_bucket_stats(
         inventory_directory=pathlib.Path(inventory_directory),
@@ -545,6 +559,25 @@ def _stats_cli(inventory_directory: str) -> None:
         rich_click.echo(f"Total size (B)  : {stats['total_size_bytes']}")
     else:
         rich_click.echo("Total size (B)  : N/A (Size column not present in inventory)")
+
+    cache_path = pathlib.Path(cache_directory) if cache_directory is not None else None
+    ip_stats = get_ip_stats(cache_directory=cache_path)
+
+    rich_click.echo("")
+    rich_click.echo(f"IPs in cache    : {ip_stats['total']}")
+
+    categories = [
+        ("determined", "Determined"),
+        ("missing", "Missing"),
+        ("unknown", "Unknown"),
+        ("bogon", "Bogon"),
+        ("vpn", "VPN"),
+        ("cloud_service", "Cloud service"),
+        ("github", "GitHub"),
+    ]
+    for key, label in categories:
+        entry = ip_stats[key]  # type: ignore[literal-required]
+        rich_click.echo(f"  {label:<14}: {entry['count']:>7}  ({entry['percent']:6.2f}%)")
 
 
 # s3logextraction completion --inventory <path> [--cache <path>]

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -541,7 +541,14 @@ def _validate_cli(
     type=rich_click.Path(exists=True, file_okay=False, dir_okay=True),
     default=None,
 )
-def _stats_cli(inventory_directory: str, cache_directory: str | None = None) -> None:
+@rich_click.option(
+    "--encryption",
+    "use_encryption",
+    help="Decrypt IP addresses in cache files. Enabled by default; pass --encryption=false for plaintext caches.",
+    type=rich_click.BOOL,
+    default=True,
+)
+def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use_encryption: bool = True) -> None:
     """
     Report log-file inventory stats and IP address classification stats.
 
@@ -561,7 +568,7 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None) -> 
         rich_click.echo("Total size (B)  : N/A (Size column not present in inventory)")
 
     cache_path = pathlib.Path(cache_directory) if cache_directory is not None else None
-    ip_stats = get_ip_stats(cache_directory=cache_path)
+    ip_stats = get_ip_stats(cache_directory=cache_path, use_encryption=use_encryption)
 
     rich_click.echo("")
     rich_click.echo(f"IPs in cache    : {ip_stats['total']}")

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -573,7 +573,9 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use
     ip_stats = get_ip_stats(cache_directory=cache_path, use_encryption=use_encryption)
 
     rich_click.echo("")
-    rich_click.echo(f"IPs in cache    : {ip_stats['total']}")
+    rich_click.echo(f"Extracted IPs   : {ip_stats['extracted_ip_count']}")
+    rich_click.echo(f"Classified IPs  : {ip_stats['classified_ip_count']}")
+    rich_click.echo(f"Percent classif.: {ip_stats['percent_classified']:.2f}%")
 
     rows: list[tuple[str, IpCategoryCount]] = [
         ("Determined", ip_stats["determined"]),

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -579,6 +579,7 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use
         ("Determined", ip_stats["determined"]),
         ("Missing", ip_stats["missing"]),
         ("Unknown", ip_stats["unknown"]),
+        ("Undetermined", ip_stats["undetermined"]),
         ("Bogon", ip_stats["bogon"]),
         ("VPN", ip_stats["vpn"]),
         ("Cloud service", ip_stats["cloud_service"]),

--- a/src/s3_log_extraction/_command_line_interface/_cli.py
+++ b/src/s3_log_extraction/_command_line_interface/_cli.py
@@ -20,7 +20,7 @@ from ..summarize import (
     generate_summaries,
 )
 from ..testing import generate_benchmark
-from ..utils import get_extraction_completion, get_ip_stats, get_log_bucket_stats
+from ..utils import IpCategoryCount, get_extraction_completion, get_ip_stats, get_log_bucket_stats
 from ..validate import (
     DownloadsLogicPreValidator,
     ExtractionHeuristicPreValidator,
@@ -573,17 +573,16 @@ def _stats_cli(inventory_directory: str, cache_directory: str | None = None, use
     rich_click.echo("")
     rich_click.echo(f"IPs in cache    : {ip_stats['total']}")
 
-    categories = [
-        ("determined", "Determined"),
-        ("missing", "Missing"),
-        ("unknown", "Unknown"),
-        ("bogon", "Bogon"),
-        ("vpn", "VPN"),
-        ("cloud_service", "Cloud service"),
-        ("github", "GitHub"),
+    rows: list[tuple[str, IpCategoryCount]] = [
+        ("Determined", ip_stats["determined"]),
+        ("Missing", ip_stats["missing"]),
+        ("Unknown", ip_stats["unknown"]),
+        ("Bogon", ip_stats["bogon"]),
+        ("VPN", ip_stats["vpn"]),
+        ("Cloud service", ip_stats["cloud_service"]),
+        ("GitHub", ip_stats["github"]),
     ]
-    for key, label in categories:
-        entry = ip_stats[key]  # type: ignore[literal-required]
+    for label, entry in rows:
         rich_click.echo(f"  {label:<14}: {entry['count']:>7}  ({entry['percent']:6.2f}%)")
 
 

--- a/src/s3_log_extraction/utils/__init__.py
+++ b/src/s3_log_extraction/utils/__init__.py
@@ -2,9 +2,12 @@ from . import encryption, inventory, parallel
 from .encryption import decrypt_bytes, encrypt_bytes, get_key, read_text_from_file, write_text_to_file
 from .inventory import (
     ExtractionCompletionStats,
+    IpCategoryCount,
+    IpStats,
     LogBucketStats,
     _read_s3_urls_from_local_inventory,
     get_extraction_completion,
+    get_ip_stats,
     get_log_bucket_stats,
 )
 from .parallel import _handle_max_workers
@@ -17,9 +20,12 @@ __all__ = [
     "encryption",
     "ExtractionCompletionStats",
     "get_extraction_completion",
+    "get_ip_stats",
     "get_key",
     "get_log_bucket_stats",
     "inventory",
+    "IpCategoryCount",
+    "IpStats",
     "LogBucketStats",
     "parallel",
     "read_text_from_file",

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -70,8 +70,9 @@ class IpStats(typing.TypedDict):
     missing : IpCategoryCount
         IPs in the cache with no region resolved (stored as ``None``).
     unknown : IpCategoryCount
-        IPs that produced an error or quota-exceeded result (``"unknown"`` or
-        ``"undetermined"``).
+        IPs where the lookup returned an unexpected error (``"unknown"``).
+    undetermined : IpCategoryCount
+        IPs where the lookup could not complete due to API quota (``"undetermined"``).
     bogon : IpCategoryCount
         IPs flagged as bogon (private / reserved address space).
     vpn : IpCategoryCount
@@ -86,6 +87,7 @@ class IpStats(typing.TypedDict):
     determined: IpCategoryCount
     missing: IpCategoryCount
     unknown: IpCategoryCount
+    undetermined: IpCategoryCount
     bogon: IpCategoryCount
     vpn: IpCategoryCount
     cloud_service: IpCategoryCount
@@ -103,7 +105,8 @@ def get_ip_stats(
 
     * **determined** – a real geographic region string (e.g. ``"US/California"``).
     * **missing** – the cache entry is ``None`` (no information could be resolved).
-    * **unknown** – the lookup returned ``"unknown"`` or ``"undetermined"``.
+    * **unknown** – the lookup returned an unexpected error (``"unknown"``).
+    * **undetermined** – the lookup hit API quota limits (``"undetermined"``).
     * **bogon** – the IP is in private / reserved address space (``"bogon"``).
     * **vpn** – the IP matches a known VPN / datacenter CIDR (starts with ``"VPN"``).
     * **cloud_service** – the IP belongs to an AWS or GCP CIDR range.
@@ -133,8 +136,10 @@ def get_ip_stats(
         match region:
             case None:
                 return "missing"
-            case "unknown" | "undetermined":
+            case "unknown":
                 return "unknown"
+            case "undetermined":
+                return "undetermined"
             case "bogon":
                 return "bogon"
             case _ if region.startswith("VPN"):
@@ -158,6 +163,7 @@ def get_ip_stats(
         determined=IpCategoryCount(count=counts["determined"], percent=_pct(counts["determined"])),
         missing=IpCategoryCount(count=counts["missing"], percent=_pct(counts["missing"])),
         unknown=IpCategoryCount(count=counts["unknown"], percent=_pct(counts["unknown"])),
+        undetermined=IpCategoryCount(count=counts["undetermined"], percent=_pct(counts["undetermined"])),
         bogon=IpCategoryCount(count=counts["bogon"], percent=_pct(counts["bogon"])),
         vpn=IpCategoryCount(count=counts["vpn"], percent=_pct(counts["vpn"])),
         cloud_service=IpCategoryCount(count=counts["cloud_service"], percent=_pct(counts["cloud_service"])),

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -94,6 +94,7 @@ class IpStats(typing.TypedDict):
 
 def get_ip_stats(
     cache_directory: str | pathlib.Path | None = None,
+    use_encryption: bool = True,
 ) -> IpStats:
     """Return classification statistics for all IP addresses in the cache.
 
@@ -112,6 +113,9 @@ def get_ip_stats(
     ----------
     cache_directory : path-like or None, optional
         Root of the cache tree.  When ``None`` the configured default is used.
+    use_encryption : bool, optional
+        If ``True`` (default), the cache file is decrypted before parsing.
+        Pass ``False`` for plaintext cache files.
 
     Returns
     -------
@@ -122,7 +126,7 @@ def get_ip_stats(
     ip_to_region: dict[str, str | None] = load_ip_cache(  # type: ignore[assignment]
         cache_type="ip_to_region",
         cache_directory=cache_directory,
-        use_encryption=True,
+        use_encryption=use_encryption,
     )
 
     counts: dict[str, int] = {

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -6,6 +6,7 @@ import pathlib
 import typing
 
 from ..ip_utils._ip_cache import load_ip_cache
+from ..ip_utils._ip_utils import _read_ips_from_file
 
 
 class LogBucketStats(typing.TypedDict):
@@ -59,20 +60,26 @@ class IpCategoryCount(typing.TypedDict):
 
 
 class IpStats(typing.TypedDict):
-    """Statistics for IP address classification in the cache.
+    """Statistics comparing extracted IPs against the ip_to_region classification cache.
 
     Attributes
     ----------
-    total : int
-        Total number of IP addresses in the cache.
+    extracted_ip_count : int
+        Number of unique IP addresses found across all ``ips.txt`` files in the
+        extraction cache.
+    classified_ip_count : int
+        Number of IP addresses present in the ``ip_to_region.yaml`` cache.
+    percent_classified : float
+        ``classified_ip_count / extracted_ip_count * 100`` (or ``0.0`` when
+        ``extracted_ip_count`` is zero).
     determined : IpCategoryCount
         IPs mapped to a concrete geographic region (country/region string).
     missing : IpCategoryCount
-        IPs in the cache with no region resolved (stored as ``None``).
+        IPs in the ``ip_to_region`` cache with no region resolved (``None``).
     unknown : IpCategoryCount
         IPs where the lookup returned an unexpected error (``"unknown"``).
     undetermined : IpCategoryCount
-        IPs where the lookup could not complete due to API quota (``"undetermined"``).
+        IPs where the lookup hit API quota limits (``"undetermined"``).
     bogon : IpCategoryCount
         IPs flagged as bogon (private / reserved address space).
     vpn : IpCategoryCount
@@ -83,7 +90,9 @@ class IpStats(typing.TypedDict):
         IPs belonging to GitHub CIDR ranges.
     """
 
-    total: int
+    extracted_ip_count: int
+    classified_ip_count: int
+    percent_classified: float
     determined: IpCategoryCount
     missing: IpCategoryCount
     unknown: IpCategoryCount
@@ -98,13 +107,14 @@ def get_ip_stats(
     cache_directory: str | pathlib.Path | None = None,
     use_encryption: bool = True,
 ) -> IpStats:
-    """Return classification statistics for all IP addresses in the cache.
+    """Return IP address stats comparing extraction cache against the classification cache.
 
-    Loads the ``ip_to_region`` cache and bins every entry into one of the
-    following mutually-exclusive categories:
+    Counts unique IPs across all ``ips.txt`` files in the extraction cache and
+    compares that against the number of entries in ``ip_to_region.yaml``.  Also
+    bins every classified entry into one of these mutually-exclusive categories:
 
     * **determined** – a real geographic region string (e.g. ``"US/California"``).
-    * **missing** – the cache entry is ``None`` (no information could be resolved).
+    * **missing** – the cache entry is ``None`` (no region could be resolved).
     * **unknown** – the lookup returned an unexpected error (``"unknown"``).
     * **undetermined** – the lookup hit API quota limits (``"undetermined"``).
     * **bogon** – the IP is in private / reserved address space (``"bogon"``).
@@ -117,20 +127,33 @@ def get_ip_stats(
     cache_directory : path-like or None, optional
         Root of the cache tree.  When ``None`` the configured default is used.
     use_encryption : bool, optional
-        If ``True`` (default), the cache file is decrypted before parsing.
-        Pass ``False`` for plaintext cache files.
+        If ``True`` (default), ``ips.txt`` and cache files are decrypted before
+        reading.  Pass ``False`` for plaintext files.
 
     Returns
     -------
     IpStats
-        A typed dict with a ``total`` key and one :class:`IpCategoryCount` entry
-        per category.
+        A typed dict with extraction vs. classification counts and per-category
+        breakdowns.
     """
+    from ..config import get_cache_directory
+
+    cache_path = pathlib.Path(cache_directory) if cache_directory is not None else get_cache_directory()
+
+    # Count unique IPs across all ips.txt files in the extraction cache
+    extracted_ips: set[str] = set()
+    for ips_file in cache_path.rglob("ips.txt"):
+        extracted_ips.update(_read_ips_from_file(file_path=ips_file, use_encryption=use_encryption))
+    extracted_ip_count = len(extracted_ips)
+
+    # Load ip_to_region classification cache
     ip_to_region: dict[str, str | None] = load_ip_cache(  # type: ignore[assignment]
         cache_type="ip_to_region",
         cache_directory=cache_directory,
         use_encryption=use_encryption,
     )
+    classified_ip_count = len(ip_to_region)
+    percent_classified = (classified_ip_count / extracted_ip_count * 100) if extracted_ip_count > 0 else 0.0
 
     def _categorize(region: str | None) -> str:
         match region:
@@ -153,13 +176,13 @@ def get_ip_stats(
 
     counts = collections.Counter(_categorize(region) for region in ip_to_region.values())
 
-    total = len(ip_to_region)
-
     def _pct(n: int) -> float:
-        return (n / total * 100) if total > 0 else 0.0
+        return (n / classified_ip_count * 100) if classified_ip_count > 0 else 0.0
 
     return IpStats(
-        total=total,
+        extracted_ip_count=extracted_ip_count,
+        classified_ip_count=classified_ip_count,
+        percent_classified=percent_classified,
         determined=IpCategoryCount(count=counts["determined"], percent=_pct(counts["determined"])),
         missing=IpCategoryCount(count=counts["missing"], percent=_pct(counts["missing"])),
         unknown=IpCategoryCount(count=counts["unknown"], percent=_pct(counts["unknown"])),

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -5,6 +5,8 @@ import json
 import pathlib
 import typing
 
+from ..ip_utils._ip_cache import load_ip_cache
+
 
 class LogBucketStats(typing.TypedDict):
     """Statistics for all objects in a local S3 Inventory.
@@ -39,6 +41,131 @@ class ExtractionCompletionStats(typing.TypedDict):
     processed_file_count: int
     inventory_file_count: int
     percent_complete: float
+
+
+class IpCategoryCount(typing.TypedDict):
+    """Count and percentage for a single IP classification category.
+
+    Attributes
+    ----------
+    count : int
+        Number of IP addresses in this category.
+    percent : float
+        Fraction of total cached IPs, expressed as a percentage.
+    """
+
+    count: int
+    percent: float
+
+
+class IpStats(typing.TypedDict):
+    """Statistics for IP address classification in the cache.
+
+    Attributes
+    ----------
+    total : int
+        Total number of IP addresses in the cache.
+    determined : IpCategoryCount
+        IPs mapped to a concrete geographic region (country/region string).
+    missing : IpCategoryCount
+        IPs in the cache with no region resolved (stored as ``None``).
+    unknown : IpCategoryCount
+        IPs that produced an error or quota-exceeded result (``"unknown"`` or
+        ``"undetermined"``).
+    bogon : IpCategoryCount
+        IPs flagged as bogon (private / reserved address space).
+    vpn : IpCategoryCount
+        IPs classified as VPN or datacenter addresses.
+    cloud_service : IpCategoryCount
+        IPs belonging to a known cloud provider CIDR (AWS or GCP).
+    github : IpCategoryCount
+        IPs belonging to GitHub CIDR ranges.
+    """
+
+    total: int
+    determined: IpCategoryCount
+    missing: IpCategoryCount
+    unknown: IpCategoryCount
+    bogon: IpCategoryCount
+    vpn: IpCategoryCount
+    cloud_service: IpCategoryCount
+    github: IpCategoryCount
+
+
+def get_ip_stats(
+    cache_directory: str | pathlib.Path | None = None,
+) -> IpStats:
+    """Return classification statistics for all IP addresses in the cache.
+
+    Loads the ``ip_to_region`` cache and bins every entry into one of the
+    following mutually-exclusive categories:
+
+    * **determined** – a real geographic region string (e.g. ``"US/California"``).
+    * **missing** – the cache entry is ``None`` (no information could be resolved).
+    * **unknown** – the lookup returned ``"unknown"`` or ``"undetermined"``.
+    * **bogon** – the IP is in private / reserved address space (``"bogon"``).
+    * **vpn** – the IP matches a known VPN / datacenter CIDR (starts with ``"VPN"``).
+    * **cloud_service** – the IP belongs to an AWS or GCP CIDR range.
+    * **github** – the IP belongs to a GitHub CIDR range.
+
+    Parameters
+    ----------
+    cache_directory : path-like or None, optional
+        Root of the cache tree.  When ``None`` the configured default is used.
+
+    Returns
+    -------
+    IpStats
+        A typed dict with a ``total`` key and one :class:`IpCategoryCount` entry
+        per category.
+    """
+    ip_to_region: dict[str, str | None] = load_ip_cache(  # type: ignore[assignment]
+        cache_type="ip_to_region",
+        cache_directory=cache_directory,
+        use_encryption=True,
+    )
+
+    counts: dict[str, int] = {
+        "determined": 0,
+        "missing": 0,
+        "unknown": 0,
+        "bogon": 0,
+        "vpn": 0,
+        "cloud_service": 0,
+        "github": 0,
+    }
+
+    for region in ip_to_region.values():
+        if region is None:
+            counts["missing"] += 1
+        elif region in ("unknown", "undetermined"):
+            counts["unknown"] += 1
+        elif region == "bogon":
+            counts["bogon"] += 1
+        elif region.startswith("VPN"):
+            counts["vpn"] += 1
+        elif region.startswith(("AWS", "GCP")):
+            counts["cloud_service"] += 1
+        elif region.startswith("GitHub"):
+            counts["github"] += 1
+        else:
+            counts["determined"] += 1
+
+    total = len(ip_to_region)
+
+    def _pct(n: int) -> float:
+        return (n / total * 100) if total > 0 else 0.0
+
+    return IpStats(
+        total=total,
+        determined=IpCategoryCount(count=counts["determined"], percent=_pct(counts["determined"])),
+        missing=IpCategoryCount(count=counts["missing"], percent=_pct(counts["missing"])),
+        unknown=IpCategoryCount(count=counts["unknown"], percent=_pct(counts["unknown"])),
+        bogon=IpCategoryCount(count=counts["bogon"], percent=_pct(counts["bogon"])),
+        vpn=IpCategoryCount(count=counts["vpn"], percent=_pct(counts["vpn"])),
+        cloud_service=IpCategoryCount(count=counts["cloud_service"], percent=_pct(counts["cloud_service"])),
+        github=IpCategoryCount(count=counts["github"], percent=_pct(counts["github"])),
+    )
 
 
 def _extract_date_from_log_filename(filename: str) -> str | None:

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -140,10 +140,13 @@ def get_ip_stats(
 
     cache_path = pathlib.Path(cache_directory) if cache_directory is not None else get_cache_directory()
 
-    # Count unique IPs across all ips.txt files in the extraction cache
+    # Count unique IPs across all ips.txt files in the extraction subdirectory,
+    # matching the scope used by update_ip_to_region_codes.
+    extraction_dir = cache_path / "extraction"
     extracted_ips: set[str] = set()
-    for ips_file in cache_path.rglob("ips.txt"):
-        extracted_ips.update(_read_ips_from_file(file_path=ips_file, use_encryption=use_encryption))
+    if extraction_dir.exists():
+        for ips_file in extraction_dir.rglob("ips.txt"):
+            extracted_ips.update(_read_ips_from_file(file_path=ips_file, use_encryption=use_encryption))
     extracted_ip_count = len(extracted_ips)
 
     # Load ip_to_region classification cache

--- a/src/s3_log_extraction/utils/inventory.py
+++ b/src/s3_log_extraction/utils/inventory.py
@@ -129,31 +129,24 @@ def get_ip_stats(
         use_encryption=use_encryption,
     )
 
-    counts: dict[str, int] = {
-        "determined": 0,
-        "missing": 0,
-        "unknown": 0,
-        "bogon": 0,
-        "vpn": 0,
-        "cloud_service": 0,
-        "github": 0,
-    }
+    def _categorize(region: str | None) -> str:
+        match region:
+            case None:
+                return "missing"
+            case "unknown" | "undetermined":
+                return "unknown"
+            case "bogon":
+                return "bogon"
+            case _ if region.startswith("VPN"):
+                return "vpn"
+            case _ if region.startswith(("AWS", "GCP")):
+                return "cloud_service"
+            case _ if region.startswith("GitHub"):
+                return "github"
+            case _:
+                return "determined"
 
-    for region in ip_to_region.values():
-        if region is None:
-            counts["missing"] += 1
-        elif region in ("unknown", "undetermined"):
-            counts["unknown"] += 1
-        elif region == "bogon":
-            counts["bogon"] += 1
-        elif region.startswith("VPN"):
-            counts["vpn"] += 1
-        elif region.startswith(("AWS", "GCP")):
-            counts["cloud_service"] += 1
-        elif region.startswith("GitHub"):
-            counts["github"] += 1
-        else:
-            counts["determined"] += 1
+    counts = collections.Counter(_categorize(region) for region in ip_to_region.values())
 
     total = len(ip_to_region)
 

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -215,9 +215,12 @@ def test_stats_cli(
         s3logextraction_cli,
         [
             "stats",
-            "--inventory", str(inventory_dir),
-            "--cache", str(cache_dir),
-            "--encryption", "false",
+            "--inventory",
+            str(inventory_dir),
+            "--cache",
+            str(cache_dir),
+            "--encryption",
+            "false",
         ],
     )
 

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -7,11 +7,12 @@ import json
 import pathlib
 
 import pytest
-import yaml
 from click.testing import CliRunner
 
 import s3_log_extraction._command_line_interface._cli as cli_module
 from s3_log_extraction._command_line_interface._cli import s3logextraction_cli
+import yaml
+
 from s3_log_extraction.utils.inventory import get_extraction_completion, get_ip_stats, get_log_bucket_stats
 
 
@@ -394,7 +395,6 @@ def test_update_totals_archive_forwards_cache_directory(
 # get_ip_stats tests
 # ---------------------------------------------------------------------------
 
-
 def _write_plaintext_ip_cache(cache_dir: pathlib.Path, data: dict) -> None:
     """Write a plaintext (unencrypted) ip_to_region.yaml cache file."""
     ips_dir = cache_dir / "ips"
@@ -411,17 +411,17 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
     and asserts that counts and percentages are computed correctly.
     """
     ip_cache = {
-        "1.1.1.1": "US/California",  # determined
-        "2.2.2.2": "AU/New South Wales",  # determined
-        "3.3.3.3": None,  # missing
-        "4.4.4.4": "unknown",  # unknown
-        "5.5.5.5": "undetermined",  # unknown (quota exceeded)
-        "6.6.6.6": "bogon",  # bogon
-        "7.7.7.7": "VPN",  # vpn
-        "8.8.8.8": "VPN/datacenter",  # vpn (sub-label)
-        "9.9.9.9": "AWS/us-east-1",  # cloud_service
+        "1.1.1.1": "US/California",       # determined
+        "2.2.2.2": "AU/New South Wales",   # determined
+        "3.3.3.3": None,                   # missing
+        "4.4.4.4": "unknown",              # unknown
+        "5.5.5.5": "undetermined",         # undetermined (quota exceeded)
+        "6.6.6.6": "bogon",                # bogon
+        "7.7.7.7": "VPN",                  # vpn
+        "8.8.8.8": "VPN/datacenter",       # vpn (sub-label)
+        "9.9.9.9": "AWS/us-east-1",        # cloud_service
         "10.10.10.10": "GCP/us-central1",  # cloud_service
-        "11.11.11.11": "GitHub",  # github
+        "11.11.11.11": "GitHub",           # github
     }
     _write_plaintext_ip_cache(tmp_path, ip_cache)
 
@@ -430,7 +430,8 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
     assert stats["total"] == 11
     assert stats["determined"]["count"] == 2
     assert stats["missing"]["count"] == 1
-    assert stats["unknown"]["count"] == 2
+    assert stats["unknown"]["count"] == 1
+    assert stats["undetermined"]["count"] == 1
     assert stats["bogon"]["count"] == 1
     assert stats["vpn"]["count"] == 2
     assert stats["cloud_service"]["count"] == 2
@@ -448,7 +449,7 @@ def test_get_ip_stats_empty_cache(tmp_path: pathlib.Path) -> None:
     stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
 
     assert stats["total"] == 0
-    for key in ("determined", "missing", "unknown", "bogon", "vpn", "cloud_service", "github"):
+    for key in ("determined", "missing", "unknown", "undetermined", "bogon", "vpn", "cloud_service", "github"):
         assert stats[key]["count"] == 0  # type: ignore[literal-required]
         assert stats[key]["percent"] == 0.0  # type: ignore[literal-required]
 

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -207,11 +207,18 @@ def test_stats_cli(
         rows=rows,
         file_schema=file_schema,
     )
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
 
     runner = CliRunner()
     result = runner.invoke(
         s3logextraction_cli,
-        ["stats", "--inventory", str(inventory_dir)],
+        [
+            "stats",
+            "--inventory", str(inventory_dir),
+            "--cache", str(cache_dir),
+            "--encryption", "false",
+        ],
     )
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -7,12 +7,11 @@ import json
 import pathlib
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 import s3_log_extraction._command_line_interface._cli as cli_module
 from s3_log_extraction._command_line_interface._cli import s3logextraction_cli
-import yaml
-
 from s3_log_extraction.utils.inventory import get_extraction_completion, get_ip_stats, get_log_bucket_stats
 
 
@@ -395,6 +394,7 @@ def test_update_totals_archive_forwards_cache_directory(
 # get_ip_stats tests
 # ---------------------------------------------------------------------------
 
+
 def _write_plaintext_ip_cache(cache_dir: pathlib.Path, data: dict) -> None:
     """Write a plaintext (unencrypted) ip_to_region.yaml cache file."""
     ips_dir = cache_dir / "ips"
@@ -411,17 +411,17 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
     and asserts that counts and percentages are computed correctly.
     """
     ip_cache = {
-        "1.1.1.1": "US/California",       # determined
-        "2.2.2.2": "AU/New South Wales",   # determined
-        "3.3.3.3": None,                   # missing
-        "4.4.4.4": "unknown",              # unknown
-        "5.5.5.5": "undetermined",         # unknown (quota exceeded)
-        "6.6.6.6": "bogon",                # bogon
-        "7.7.7.7": "VPN",                  # vpn
-        "8.8.8.8": "VPN/datacenter",       # vpn (sub-label)
-        "9.9.9.9": "AWS/us-east-1",        # cloud_service
+        "1.1.1.1": "US/California",  # determined
+        "2.2.2.2": "AU/New South Wales",  # determined
+        "3.3.3.3": None,  # missing
+        "4.4.4.4": "unknown",  # unknown
+        "5.5.5.5": "undetermined",  # unknown (quota exceeded)
+        "6.6.6.6": "bogon",  # bogon
+        "7.7.7.7": "VPN",  # vpn
+        "8.8.8.8": "VPN/datacenter",  # vpn (sub-label)
+        "9.9.9.9": "AWS/us-east-1",  # cloud_service
         "10.10.10.10": "GCP/us-central1",  # cloud_service
-        "11.11.11.11": "GitHub",           # github
+        "11.11.11.11": "GitHub",  # github
     }
     _write_plaintext_ip_cache(tmp_path, ip_cache)
 

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -7,12 +7,11 @@ import json
 import pathlib
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 import s3_log_extraction._command_line_interface._cli as cli_module
 from s3_log_extraction._command_line_interface._cli import s3logextraction_cli
-import yaml
-
 from s3_log_extraction.utils.inventory import get_extraction_completion, get_ip_stats, get_log_bucket_stats
 
 
@@ -395,6 +394,7 @@ def test_update_totals_archive_forwards_cache_directory(
 # get_ip_stats tests
 # ---------------------------------------------------------------------------
 
+
 def _write_plaintext_ip_cache(cache_dir: pathlib.Path, data: dict) -> None:
     """Write a plaintext (unencrypted) ip_to_region.yaml cache file."""
     ips_dir = cache_dir / "ips"
@@ -411,17 +411,17 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
     and asserts that counts and percentages are computed correctly.
     """
     ip_cache = {
-        "1.1.1.1": "US/California",       # determined
-        "2.2.2.2": "AU/New South Wales",   # determined
-        "3.3.3.3": None,                   # missing
-        "4.4.4.4": "unknown",              # unknown
-        "5.5.5.5": "undetermined",         # undetermined (quota exceeded)
-        "6.6.6.6": "bogon",                # bogon
-        "7.7.7.7": "VPN",                  # vpn
-        "8.8.8.8": "VPN/datacenter",       # vpn (sub-label)
-        "9.9.9.9": "AWS/us-east-1",        # cloud_service
+        "1.1.1.1": "US/California",  # determined
+        "2.2.2.2": "AU/New South Wales",  # determined
+        "3.3.3.3": None,  # missing
+        "4.4.4.4": "unknown",  # unknown
+        "5.5.5.5": "undetermined",  # undetermined (quota exceeded)
+        "6.6.6.6": "bogon",  # bogon
+        "7.7.7.7": "VPN",  # vpn
+        "8.8.8.8": "VPN/datacenter",  # vpn (sub-label)
+        "9.9.9.9": "AWS/us-east-1",  # cloud_service
         "10.10.10.10": "GCP/us-central1",  # cloud_service
-        "11.11.11.11": "GitHub",           # github
+        "11.11.11.11": "GitHub",  # github
     }
     _write_plaintext_ip_cache(tmp_path, ip_cache)
 

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -11,7 +11,9 @@ from click.testing import CliRunner
 
 import s3_log_extraction._command_line_interface._cli as cli_module
 from s3_log_extraction._command_line_interface._cli import s3logextraction_cli
-from s3_log_extraction.utils.inventory import get_extraction_completion, get_log_bucket_stats
+import yaml
+
+from s3_log_extraction.utils.inventory import get_extraction_completion, get_ip_stats, get_log_bucket_stats
 
 
 def _build_inventory_directory(
@@ -387,3 +389,75 @@ def test_update_totals_archive_forwards_cache_directory(
 
     assert result.exit_code == 0, f"CLI failed: {result.output}"
     assert captured["cache_directory"] == cache_dir
+
+
+# ---------------------------------------------------------------------------
+# get_ip_stats tests
+# ---------------------------------------------------------------------------
+
+def _write_plaintext_ip_cache(cache_dir: pathlib.Path, data: dict) -> None:
+    """Write a plaintext (unencrypted) ip_to_region.yaml cache file."""
+    ips_dir = cache_dir / "ips"
+    ips_dir.mkdir(parents=True, exist_ok=True)
+    (ips_dir / "ip_to_region.yaml").write_text(yaml.dump(data))
+
+
+@pytest.mark.ai_generated
+def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
+    """
+    get_ip_stats correctly bins every classification category.
+
+    Writes a plaintext ip_to_region cache covering all seven categories
+    and asserts that counts and percentages are computed correctly.
+    """
+    ip_cache = {
+        "1.1.1.1": "US/California",       # determined
+        "2.2.2.2": "AU/New South Wales",   # determined
+        "3.3.3.3": None,                   # missing
+        "4.4.4.4": "unknown",              # unknown
+        "5.5.5.5": "undetermined",         # unknown (quota exceeded)
+        "6.6.6.6": "bogon",                # bogon
+        "7.7.7.7": "VPN",                  # vpn
+        "8.8.8.8": "VPN/datacenter",       # vpn (sub-label)
+        "9.9.9.9": "AWS/us-east-1",        # cloud_service
+        "10.10.10.10": "GCP/us-central1",  # cloud_service
+        "11.11.11.11": "GitHub",           # github
+    }
+    _write_plaintext_ip_cache(tmp_path, ip_cache)
+
+    stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
+
+    assert stats["total"] == 11
+    assert stats["determined"]["count"] == 2
+    assert stats["missing"]["count"] == 1
+    assert stats["unknown"]["count"] == 2
+    assert stats["bogon"]["count"] == 1
+    assert stats["vpn"]["count"] == 2
+    assert stats["cloud_service"]["count"] == 2
+    assert stats["github"]["count"] == 1
+
+    assert abs(stats["determined"]["percent"] - 2 / 11 * 100) < 0.01
+    assert abs(stats["cloud_service"]["percent"] - 2 / 11 * 100) < 0.01
+
+
+@pytest.mark.ai_generated
+def test_get_ip_stats_empty_cache(tmp_path: pathlib.Path) -> None:
+    """get_ip_stats returns zeros and 0.0% for an empty cache."""
+    _write_plaintext_ip_cache(tmp_path, {})
+
+    stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
+
+    assert stats["total"] == 0
+    for key in ("determined", "missing", "unknown", "bogon", "vpn", "cloud_service", "github"):
+        assert stats[key]["count"] == 0  # type: ignore[literal-required]
+        assert stats[key]["percent"] == 0.0  # type: ignore[literal-required]
+
+
+@pytest.mark.ai_generated
+def test_get_ip_stats_missing_cache_file(tmp_path: pathlib.Path) -> None:
+    """get_ip_stats returns zeros when the cache file does not exist yet."""
+    (tmp_path / "ips").mkdir(parents=True)  # dir exists but no yaml file
+
+    stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
+
+    assert stats["total"] == 0

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -167,7 +167,7 @@ _CLI_PARAMS = [
             (SOURCE_BUCKET, "other/2024-01-02-00-00-00-BBBB", 400),
             (SOURCE_BUCKET, "other/2024-01-02-00-05-00-CCCC", 500),
         ],
-        ["File count", "Total size", "3", "1000"],
+        ["File count", "3"],
         id="with_size_column",
     ),
     pytest.param(
@@ -177,7 +177,7 @@ _CLI_PARAMS = [
             (SOURCE_BUCKET, "logs/2024-01-02-00-00-00-BBBB"),
             (SOURCE_BUCKET, "other/2024-01-03-00-00-00-CCCC"),
         ],
-        ["File count", "3", "N/A"],
+        ["File count", "3"],
         id="without_size_column",
     ),
 ]
@@ -198,7 +198,7 @@ def test_stats_cli(
     The 'stats' CLI command counts all inventory keys and produces the expected output.
 
     Covers the ``Size`` column present and absent cases, and validates that the
-    ``File count`` and ``Total size`` labels always appear.
+    ``File count`` label always appears.
     """
     inventory_dir = _build_inventory_directory(
         tmp_path,

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -402,14 +402,39 @@ def _write_plaintext_ip_cache(cache_dir: pathlib.Path, data: dict) -> None:
     (ips_dir / "ip_to_region.yaml").write_text(yaml.dump(data))
 
 
+def _write_plaintext_ips_txt(cache_dir: pathlib.Path, subpath: str, ips: list[str]) -> None:
+    """Write a plaintext (unencrypted) ips.txt file at cache_dir/subpath/ips.txt."""
+    target = cache_dir / subpath
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "ips.txt").write_text("\n".join(ips) + "\n")
+
+
 @pytest.mark.ai_generated
 def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
     """
     get_ip_stats correctly bins every classification category.
 
-    Writes a plaintext ip_to_region cache covering all seven categories
-    and asserts that counts and percentages are computed correctly.
+    Writes plaintext ips.txt and ip_to_region cache files covering all eight
+    categories and asserts that extracted/classified counts and per-category
+    percentages are computed correctly.
     """
+    all_ips = [
+        "1.1.1.1",
+        "2.2.2.2",
+        "3.3.3.3",
+        "4.4.4.4",
+        "5.5.5.5",
+        "6.6.6.6",
+        "7.7.7.7",
+        "8.8.8.8",
+        "9.9.9.9",
+        "10.10.10.10",
+        "11.11.11.11",
+        "12.12.12.12",  # extracted but not yet classified
+    ]
+    _write_plaintext_ips_txt(tmp_path, "dataset/asset1", all_ips[:6])
+    _write_plaintext_ips_txt(tmp_path, "dataset/asset2", all_ips[6:])
+
     ip_cache = {
         "1.1.1.1": "US/California",  # determined
         "2.2.2.2": "AU/New South Wales",  # determined
@@ -427,7 +452,10 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
 
     stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
 
-    assert stats["total"] == 11
+    assert stats["extracted_ip_count"] == 12
+    assert stats["classified_ip_count"] == 11
+    assert abs(stats["percent_classified"] - 11 / 12 * 100) < 0.01
+
     assert stats["determined"]["count"] == 2
     assert stats["missing"]["count"] == 1
     assert stats["unknown"]["count"] == 1
@@ -448,7 +476,9 @@ def test_get_ip_stats_empty_cache(tmp_path: pathlib.Path) -> None:
 
     stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
 
-    assert stats["total"] == 0
+    assert stats["extracted_ip_count"] == 0
+    assert stats["classified_ip_count"] == 0
+    assert stats["percent_classified"] == 0.0
     for key in ("determined", "missing", "unknown", "undetermined", "bogon", "vpn", "cloud_service", "github"):
         assert stats[key]["count"] == 0  # type: ignore[literal-required]
         assert stats[key]["percent"] == 0.0  # type: ignore[literal-required]
@@ -461,4 +491,5 @@ def test_get_ip_stats_missing_cache_file(tmp_path: pathlib.Path) -> None:
 
     stats = get_ip_stats(cache_directory=tmp_path, use_encryption=False)
 
-    assert stats["total"] == 0
+    assert stats["extracted_ip_count"] == 0
+    assert stats["classified_ip_count"] == 0

--- a/tests/test_log_bucket_stats.py
+++ b/tests/test_log_bucket_stats.py
@@ -442,8 +442,8 @@ def test_get_ip_stats_all_categories(tmp_path: pathlib.Path) -> None:
         "11.11.11.11",
         "12.12.12.12",  # extracted but not yet classified
     ]
-    _write_plaintext_ips_txt(tmp_path, "dataset/asset1", all_ips[:6])
-    _write_plaintext_ips_txt(tmp_path, "dataset/asset2", all_ips[6:])
+    _write_plaintext_ips_txt(tmp_path, "extraction/dataset/asset1", all_ips[:6])
+    _write_plaintext_ips_txt(tmp_path, "extraction/dataset/asset2", all_ips[6:])
 
     ip_cache = {
         "1.1.1.1": "US/California",  # determined


### PR DESCRIPTION
## Summary
This PR adds IP address classification statistics to the `stats` command, allowing users to see a breakdown of how IP addresses in the cache are categorized (determined, missing, unknown, bogon, VPN, cloud service, GitHub).

## Key Changes
- **New TypedDict classes** (`IpCategoryCount` and `IpStats`) to structure IP statistics data with counts and percentages for each classification category
- **New `get_ip_stats()` function** that loads the IP-to-region cache and bins all entries into mutually-exclusive categories:
  - **determined**: Real geographic region strings (e.g., "US/California")
  - **missing**: Cache entries with `None` value
  - **unknown**: Entries with "unknown" or "undetermined" values
  - **bogon**: Private/reserved address space
  - **vpn**: VPN/datacenter CIDR ranges (prefix "VPN")
  - **cloud_service**: AWS or GCP CIDR ranges (prefix "AWS" or "GCP")
  - **github**: GitHub CIDR ranges (prefix "GitHub")
- **Enhanced `stats` CLI command** with optional `--cache` parameter to specify a custom cache directory
- **Updated command output** to display IP statistics alongside existing inventory statistics, showing count and percentage for each category
- **Updated exports** in `utils/__init__.py` to expose new types and functions

## Implementation Details
- The `get_ip_stats()` function calculates percentages safely, returning 0.0 when the cache is empty
- Categories are mutually-exclusive with a clear precedence order (checked in sequence)
- The CLI output is formatted consistently with existing stats output, using aligned columns for readability

https://claude.ai/code/session_011P2oXRraRrd1Yg7i7TVWiK