### PR TITLE
Don't re-queue undetermined IPs in update_ip_to_region_codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.4"
+version="1.10.5"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
@@ -62,8 +62,11 @@ def update_ip_to_region_codes(
     ip_to_region = load_ip_cache(
         cache_type="ip_to_region", cache_directory=cache_directory, use_encryption=use_encryption
     )
-    ip_to_determined_region = {ip: region for ip, region in ip_to_region.items() if region != "undetermined"}
-    ips_to_update = list(all_ips - set(ip_to_determined_region.keys()))
+    # Exclude all IPs already in the cache, including those stored as "undetermined"
+    # (quota-exceeded). Retrying undetermined IPs every run wastes batch slots on
+    # IPs that were only skipped due to a transient quota limit; the refresh command
+    # exists specifically to retry those.
+    ips_to_update = list(all_ips - set(ip_to_region.keys()))
 
     # If a batch limit is set, shuffle the IPs to ensure repeated runs update different IPs
     if batch_limit is not None:

--- a/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
@@ -62,7 +62,7 @@ def update_ip_to_region_codes(
     ip_to_region = load_ip_cache(
         cache_type="ip_to_region", cache_directory=cache_directory, use_encryption=use_encryption
     )
-    # Skip IPs already in the cache (including "undetermined"); use the refresh command to retry those.
+    # Skip IPs already in the cache (including "undetermined"); use the refresh command to retry those
     ips_to_update = list(all_ips - set(ip_to_region.keys()))
 
     # If a batch limit is set, shuffle the IPs to ensure repeated runs update different IPs

--- a/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
@@ -62,10 +62,7 @@ def update_ip_to_region_codes(
     ip_to_region = load_ip_cache(
         cache_type="ip_to_region", cache_directory=cache_directory, use_encryption=use_encryption
     )
-    # Exclude all IPs already in the cache, including those stored as "undetermined"
-    # (quota-exceeded). Retrying undetermined IPs every run wastes batch slots on
-    # IPs that were only skipped due to a transient quota limit; the refresh command
-    # exists specifically to retry those.
+    # Skip IPs already in the cache (including "undetermined"); use the refresh command to retry those.
     ips_to_update = list(all_ips - set(ip_to_region.keys()))
 
     # If a batch limit is set, shuffle the IPs to ensure repeated runs update different IPs


### PR DESCRIPTION
## Summary

- IPs stored as `"undetermined"` (API quota exceeded) were re-queued on every run, wasting batch slots that should go to genuinely new IPs
- Fix: skip any IP already present in the cache regardless of its stored value — only truly new IPs consume batch budget
- The existing `refresh` command handles periodic re-querying of stale entries on a 90-day cycle

## Test plan

- [ ] Verify existing tests pass
- [ ] Manually confirm a second run with `--batch-limit 1` no longer re-processes IPs marked `undetermined` in the previous run

https://claude.ai/code/session_011P2oXRraRrd1Yg7i7TVWiK