### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,9 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions:
+  contents: read
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/dandi/s3-log-extraction/security/code-scanning/15](https://github.com/dandi/s3-log-extraction/security/code-scanning/15)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted.  
Best fix here: set workflow-level permissions right after `on:`/`workflow_call` and before `env` so all jobs inherit it unless overridden.

For this workflow, minimal required permission is:
- `contents: read`

Edit file:
- `.github/workflows/testing.yml`  
- Insert under the existing `on.workflow_call.secrets` section (after line 8 in the snippet), before `env:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
