### PR TITLE
Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_and_upload_docker_image_dev.yml
+++ b/.github/workflows/build_and_upload_docker_image_dev.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build-test-push:
     name: Build and upload Docker image of dev branch to GHCR

--- a/.github/workflows/build_and_upload_docker_image_latest.yml
+++ b/.github/workflows/build_and_upload_docker_image_latest.yml
@@ -6,6 +6,10 @@ on:
     workflows: [Upload Package to PyPI]
     types: [completed]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   release-image:
     name: Build and upload Docker image of latest release to GHCR

--- a/.github/workflows/daily_remote_tests.yml
+++ b/.github/workflows/daily_remote_tests.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   DailyRemoteTests:

--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   DailyTests:

--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   Tests:

--- a/.github/workflows/publish_to_pypi_on_github_release.yml
+++ b/.github/workflows/publish_to_pypi_on_github_release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/remote_testing.yml
+++ b/.github/workflows/remote_testing.yml
@@ -11,6 +11,9 @@ on:
       CODECOV_CREDENTIALS:
         required: true
 
+permissions:
+  contents: read
+
 env:
   S3_LOG_EXTRACTION_PASSWORD: ${{ secrets.S3_LOG_EXTRACTION_PASSWORD }}
   IPINFO_API_KEY: ${{ secrets.IPINFO_API_KEY }}


### PR DESCRIPTION
## Summary
This PR adds explicit permission declarations to all GitHub Actions workflows to follow the principle of least privilege and improve security posture.

## Key Changes
- Added `permissions` block to 7 workflows with minimal required permissions:
  - `build_and_upload_docker_image_dev.yml`: `contents: read` and `packages: write` (for pushing to GHCR)
  - `build_and_upload_docker_image_latest.yml`: `contents: read` and `packages: write` (for pushing to GHCR)
  - `daily_remote_tests.yml`: `contents: read`
  - `daily_tests.yml`: `contents: read`
  - `deploy_tests_on_pull_request.yml`: `contents: read`
  - `publish_to_pypi_on_github_release.yml`: `contents: read`
  - `remote_testing.yml`: `contents: read`

## Implementation Details
- Each workflow now explicitly declares only the permissions it requires
- Docker image workflows require `packages: write` to push images to GitHub Container Registry (GHCR)
- All workflows require `contents: read` to access repository contents
- This prevents workflows from having unnecessary access to other resources by default
- Follows GitHub's security best practices for workflow permissions

https://claude.ai/code/session_017m4JYyCuytuMjwKakTqyT3