### PR TITLE
Replace SHA256 with PBKDF2-HMAC-SHA256 for key derivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 - Strengthened encryption key derivation. The `S3_LOG_EXTRACTION_PASSWORD` value now passes through PBKDF2-HMAC-SHA256 instead of a single SHA-256 pass, which resists brute-force attacks. Weak passwords are also rejected before any encryption runs. A public `validate_password_strength` helper was added. ([#283](https://github.com/dandi/s3-log-extraction/pull/283))
 - Added the `s3logextraction stats` CLI command and the `get_log_bucket_stats` API helper for summarizing S3 inventory. ([#224](https://github.com/dandi/s3-log-extraction/pull/224))
+- Extended the `s3logextraction stats` command and added a `get_ip_stats` API helper to report IP address classification statistics from the IP cache. Every cached IP is binned into one of seven categories (determined, missing, unknown, bogon, VPN, cloud service, GitHub) with counts and percentages. The command also gains `--cache` and `--encryption` flags. ([#274](https://github.com/dandi/s3-log-extraction/pull/274))
 
 ### 🐛 Bug Fix
 
-- Fixed the IPInfo quota-exceeded fallback so daily remote tests return `undetermined` instead of crashing on Python 3.14 when a warning is emitted. ([#N](https://github.com/dandi/s3-log-extraction/pull/N))
+- Fixed the IPInfo quota-exceeded fallback so daily remote tests return `undetermined` instead of crashing on Python 3.14 when a warning is emitted. ([#273](https://github.com/dandi/s3-log-extraction/pull/273))
 
 
 ## v1.10.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🚀 Enhancement
 
 - Strengthened encryption key derivation. The `S3_LOG_EXTRACTION_PASSWORD` value now passes through PBKDF2-HMAC-SHA256 instead of a single SHA-256 pass, which resists brute-force attacks. Weak passwords are also rejected before any encryption runs. A public `validate_password_strength` helper was added. ([#283](https://github.com/dandi/s3-log-extraction/pull/283))
-- Backfilled a missing changelog entry. The `s3logextraction stats` CLI command and the `get_log_bucket_stats` API helper for S3 inventory summarization were added earlier but never recorded here. ([#224](https://github.com/dandi/s3-log-extraction/pull/224))
+- Added the `s3logextraction stats` CLI command and the `get_log_bucket_stats` API helper for summarizing S3 inventory. ([#224](https://github.com/dandi/s3-log-extraction/pull/224))
 
 ### 🐛 Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🚀 Enhancement
 
 - Strengthened encryption key derivation. The `S3_LOG_EXTRACTION_PASSWORD` value now passes through PBKDF2-HMAC-SHA256 instead of a single SHA-256 pass, which resists brute-force attacks. Weak passwords are also rejected before any encryption runs. A public `validate_password_strength` helper was added. ([#283](https://github.com/dandi/s3-log-extraction/pull/283))
+- Backfilled a missing changelog entry. The `s3logextraction stats` CLI command and the `get_log_bucket_stats` API helper for S3 inventory summarization were added earlier but never recorded here. ([#224](https://github.com/dandi/s3-log-extraction/pull/224))
 
 ### 🐛 Bug Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### 🚀 Enhancement
+
+- Strengthened encryption key derivation. The `S3_LOG_EXTRACTION_PASSWORD` value now passes through PBKDF2-HMAC-SHA256 instead of a single SHA-256 pass, which resists brute-force attacks. Weak passwords are also rejected before any encryption runs. A public `validate_password_strength` helper was added. ([#283](https://github.com/dandi/s3-log-extraction/pull/283))
+
 ### 🐛 Bug Fix
 
 - Fixed the IPInfo quota-exceeded fallback so daily remote tests return `undetermined` instead of crashing on Python 3.14 when a warning is emitted. ([#N](https://github.com/dandi/s3-log-extraction/pull/N))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.5"
+version="1.10.6"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/s3_log_extraction/utils/__init__.py
+++ b/src/s3_log_extraction/utils/__init__.py
@@ -1,5 +1,12 @@
 from . import encryption, inventory, parallel
-from .encryption import decrypt_bytes, encrypt_bytes, get_key, read_text_from_file, write_text_to_file
+from .encryption import (
+    decrypt_bytes,
+    encrypt_bytes,
+    get_key,
+    read_text_from_file,
+    validate_password_strength,
+    write_text_to_file,
+)
 from .inventory import (
     ExtractionCompletionStats,
     IpCategoryCount,
@@ -29,5 +36,6 @@ __all__ = [
     "LogBucketStats",
     "parallel",
     "read_text_from_file",
+    "validate_password_strength",
     "write_text_to_file",
 ]

--- a/src/s3_log_extraction/utils/encryption.py
+++ b/src/s3_log_extraction/utils/encryption.py
@@ -188,13 +188,3 @@ def write_text_to_file(*, file_path: pathlib.Path, text: str, use_encryption: bo
         file_path.write_bytes(encrypt_bytes(text.encode(encoding="utf-8")))
     else:
         file_path.write_text(text)
-
-
-__all__ = [
-    "decrypt_bytes",
-    "encrypt_bytes",
-    "get_key",
-    "read_text_from_file",
-    "validate_password_strength",
-    "write_text_to_file",
-]

--- a/src/s3_log_extraction/utils/encryption.py
+++ b/src/s3_log_extraction/utils/encryption.py
@@ -1,6 +1,8 @@
 import base64
+import math
 import os
 import pathlib
+import string
 
 import cryptography.fernet
 from cryptography.hazmat.primitives import hashes
@@ -15,6 +17,66 @@ _DEFAULT_SALT = b"s3_log_extraction"
 # Number of PBKDF2 iterations; follows the OWASP recommendation for PBKDF2-HMAC-SHA256.
 _KDF_ITERATIONS = 600_000
 
+# Minimum password requirements. These are tuned to comfortably accept randomly generated high-entropy
+# secrets (such as `secrets.token_urlsafe`, `secrets.token_hex`, or UUIDs) while rejecting short or
+# low-variety human-chosen passwords. A password is the only secret protecting encrypted data at rest,
+# so it must not be brute-forceable.
+_MINIMUM_PASSWORD_LENGTH = 16
+_MINIMUM_DISTINCT_CHARACTERS = 8
+_MINIMUM_ENTROPY_BITS = 90.0
+
+
+def _estimate_entropy_bits(password: str) -> float:
+    """Estimate the entropy of a password in bits from its length and the character classes it uses."""
+    charset_size = 0
+    if any(character in string.ascii_lowercase for character in password):
+        charset_size += 26
+    if any(character in string.ascii_uppercase for character in password):
+        charset_size += 26
+    if any(character in string.digits for character in password):
+        charset_size += 10
+    if any(character in string.punctuation for character in password):
+        charset_size += len(string.punctuation)
+    if any(character not in string.printable for character in password):
+        charset_size += 100  # Conservative allowance for non-ASCII (e.g. unicode) characters.
+
+    if charset_size == 0:
+        return 0.0
+    return len(password) * math.log2(charset_size)
+
+
+def validate_password_strength(password: str) -> None:
+    """Raise a ``ValueError`` if the password is too weak to be used for encryption.
+
+    The checks are intentionally heuristic: they enforce a minimum length, a minimum number of distinct
+    characters, and a minimum estimated entropy. They are designed to block weak human-chosen passwords
+    while accepting randomly generated secrets. They cannot detect dictionary words embedded in an
+    otherwise long string, so a randomly generated secret is always recommended.
+    """
+    problems = []
+    if len(password) < _MINIMUM_PASSWORD_LENGTH:
+        problems.append(f"it must be at least {_MINIMUM_PASSWORD_LENGTH} characters long (got {len(password)})")
+    distinct_characters = len(set(password))
+    if distinct_characters < _MINIMUM_DISTINCT_CHARACTERS:
+        problems.append(
+            f"it must contain at least {_MINIMUM_DISTINCT_CHARACTERS} distinct characters (got {distinct_characters})"
+        )
+    entropy_bits = _estimate_entropy_bits(password)
+    if entropy_bits < _MINIMUM_ENTROPY_BITS:
+        problems.append(
+            f"its estimated entropy must be at least {_MINIMUM_ENTROPY_BITS:.0f} bits (got {entropy_bits:.0f})"
+        )
+
+    if problems:
+        joined_problems = "; ".join(problems)
+        message = (
+            "The value of the `S3_LOG_EXTRACTION_PASSWORD` environment variable is not strong enough: "
+            f"{joined_problems}. "
+            "Please use a randomly generated secret, for example the output of `python -c \"import secrets; "
+            'print(secrets.token_urlsafe(32))"`.'
+        )
+        raise ValueError(message)
+
 
 def get_key() -> bytes:
     """Parse the full byte key for the given password.
@@ -22,11 +84,14 @@ def get_key() -> bytes:
     The key is derived from the `S3_LOG_EXTRACTION_PASSWORD` environment variable using PBKDF2-HMAC-SHA256,
     a deliberately expensive key derivation function that is resistant to brute-force attacks.
     The salt may be customized via the `S3_LOG_EXTRACTION_SALT` environment variable.
+
+    The password is validated against minimum strength requirements before use; weak passwords are rejected.
     """
     password = os.environ.get("S3_LOG_EXTRACTION_PASSWORD", None)
     if password is None:
         message = "Environment variable `S3_LOG_EXTRACTION_PASSWORD` is not set - unable to run encryption tools."
         raise EnvironmentError(message)
+    validate_password_strength(password=password)
 
     salt = os.environ.get("S3_LOG_EXTRACTION_SALT", None)
     salt_bytes = salt.encode(encoding="utf-8") if salt is not None else _DEFAULT_SALT
@@ -125,5 +190,6 @@ __all__ = [
     "encrypt_bytes",
     "get_key",
     "read_text_from_file",
+    "validate_password_strength",
     "write_text_to_file",
 ]

--- a/src/s3_log_extraction/utils/encryption.py
+++ b/src/s3_log_extraction/utils/encryption.py
@@ -1,22 +1,41 @@
 import base64
-import hashlib
 import os
 import pathlib
 
 import cryptography.fernet
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+# Default salt used when `S3_LOG_EXTRACTION_SALT` is not set.
+# The key derivation must be deterministic so that data encrypted in one run can be decrypted in another,
+# which means the salt has to be stable rather than randomly generated per call.
+# It can be overridden with the `S3_LOG_EXTRACTION_SALT` environment variable for stronger separation.
+_DEFAULT_SALT = b"s3_log_extraction"
+
+# Number of PBKDF2 iterations; follows the OWASP recommendation for PBKDF2-HMAC-SHA256.
+_KDF_ITERATIONS = 600_000
 
 
 def get_key() -> bytes:
-    """Parse the full byte key for the given password."""
+    """Parse the full byte key for the given password.
+
+    The key is derived from the `S3_LOG_EXTRACTION_PASSWORD` environment variable using PBKDF2-HMAC-SHA256,
+    a deliberately expensive key derivation function that is resistant to brute-force attacks.
+    The salt may be customized via the `S3_LOG_EXTRACTION_SALT` environment variable.
+    """
     password = os.environ.get("S3_LOG_EXTRACTION_PASSWORD", None)
     if password is None:
         message = "Environment variable `S3_LOG_EXTRACTION_PASSWORD` is not set - unable to run encryption tools."
         raise EnvironmentError(message)
 
-    password_bytes = password.encode(encoding="utf-8")
-    hexcode = hashlib.sha256(password_bytes).digest()
+    salt = os.environ.get("S3_LOG_EXTRACTION_SALT", None)
+    salt_bytes = salt.encode(encoding="utf-8") if salt is not None else _DEFAULT_SALT
 
-    key = base64.urlsafe_b64encode(hexcode)
+    password_bytes = password.encode(encoding="utf-8")
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt_bytes, iterations=_KDF_ITERATIONS)
+    derived_key = kdf.derive(key_material=password_bytes)
+
+    key = base64.urlsafe_b64encode(derived_key)
     return key
 
 

--- a/src/s3_log_extraction/utils/encryption.py
+++ b/src/s3_log_extraction/utils/encryption.py
@@ -5,8 +5,8 @@ import pathlib
 import string
 
 import cryptography.fernet
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+import cryptography.hazmat.primitives.hashes
+import cryptography.hazmat.primitives.kdf.pbkdf2
 
 # Default salt used when `S3_LOG_EXTRACTION_SALT` is not set.
 # The key derivation must be deterministic so that data encrypted in one run can be decrypted in another,
@@ -26,7 +26,7 @@ _MINIMUM_DISTINCT_CHARACTERS = 8
 _MINIMUM_ENTROPY_BITS = 90.0
 
 
-def _estimate_entropy_bits(password: str) -> float:
+def _estimate_entropy_bits(password: str, /) -> float:
     """Estimate the entropy of a password in bits from its length and the character classes it uses."""
     charset_size = 0
     if any(character in string.ascii_lowercase for character in password):
@@ -45,7 +45,7 @@ def _estimate_entropy_bits(password: str) -> float:
     return len(password) * math.log2(charset_size)
 
 
-def validate_password_strength(password: str) -> None:
+def validate_password_strength(password: str, /) -> None:
     """Raise a ``ValueError`` if the password is too weak to be used for encryption.
 
     The checks are intentionally heuristic: they enforce a minimum length, a minimum number of distinct
@@ -91,13 +91,18 @@ def get_key() -> bytes:
     if password is None:
         message = "Environment variable `S3_LOG_EXTRACTION_PASSWORD` is not set - unable to run encryption tools."
         raise EnvironmentError(message)
-    validate_password_strength(password=password)
+    validate_password_strength(password)
 
     salt = os.environ.get("S3_LOG_EXTRACTION_SALT", None)
     salt_bytes = salt.encode(encoding="utf-8") if salt is not None else _DEFAULT_SALT
 
     password_bytes = password.encode(encoding="utf-8")
-    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt_bytes, iterations=_KDF_ITERATIONS)
+    kdf = cryptography.hazmat.primitives.kdf.pbkdf2.PBKDF2HMAC(
+        algorithm=cryptography.hazmat.primitives.hashes.SHA256(),
+        length=32,
+        salt=salt_bytes,
+        iterations=_KDF_ITERATIONS,
+    )
     derived_key = kdf.derive(key_material=password_bytes)
 
     key = base64.urlsafe_b64encode(derived_key)

--- a/src/s3_log_extraction/utils/encryption.py
+++ b/src/s3_log_extraction/utils/encryption.py
@@ -72,7 +72,7 @@ def validate_password_strength(password: str) -> None:
         message = (
             "The value of the `S3_LOG_EXTRACTION_PASSWORD` environment variable is not strong enough: "
             f"{joined_problems}. "
-            "Please use a randomly generated secret, for example the output of `python -c \"import secrets; "
+            'Please use a randomly generated secret, for example the output of `python -c "import secrets; '
             'print(secrets.token_urlsafe(32))"`.'
         )
         raise ValueError(message)

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -1,0 +1,153 @@
+"""Tests for the encryption utilities, including password-strength enforcement."""
+
+import pathlib
+import secrets
+import uuid
+
+import cryptography.fernet
+import pytest
+
+import s3_log_extraction
+
+# A randomly generated, high-entropy secret of the kind that should always be accepted.
+_STRONG_PASSWORD = secrets.token_urlsafe(32)
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "generated_password",
+    [
+        secrets.token_urlsafe(32),
+        secrets.token_urlsafe(16),
+        secrets.token_hex(16),
+        uuid.uuid4().hex,
+    ],
+)
+def test_validate_password_strength_accepts_generated_secrets(generated_password: str) -> None:
+    """Randomly generated high-entropy secrets should pass validation without raising."""
+    s3_log_extraction.utils.validate_password_strength(generated_password)
+
+
+@pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    "weak_password",
+    [
+        "hunter2",  # too short
+        "Password123!",  # too short (12 characters)
+        "aaaaaaaaaaaaaaaaaaaa",  # long but only one distinct character
+        "12345678901234567890",  # long but only digits, so low entropy
+    ],
+)
+def test_validate_password_strength_rejects_weak_passwords(weak_password: str) -> None:
+    """Short or low-variety human-chosen passwords should be rejected."""
+    with pytest.raises(ValueError, match="not strong enough"):
+        s3_log_extraction.utils.validate_password_strength(weak_password)
+
+
+@pytest.mark.ai_generated
+def test_validate_password_strength_error_mentions_env_var_and_recommendation() -> None:
+    """The error message should name the environment variable and suggest a generated secret."""
+    with pytest.raises(ValueError) as error_info:
+        s3_log_extraction.utils.validate_password_strength("short")
+
+    message = str(error_info.value)
+    assert ("S3_LOG_EXTRACTION_PASSWORD" in message) is True
+    assert ("secrets.token_urlsafe" in message) is True
+
+
+@pytest.mark.ai_generated
+def test_get_key_requires_environment_variable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_key should raise EnvironmentError when the password variable is unset."""
+    monkeypatch.delenv("S3_LOG_EXTRACTION_PASSWORD", raising=False)
+
+    with pytest.raises(EnvironmentError, match="S3_LOG_EXTRACTION_PASSWORD"):
+        s3_log_extraction.utils.get_key()
+
+
+@pytest.mark.ai_generated
+def test_get_key_rejects_weak_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_key should refuse to derive a key from a weak password before any encryption happens."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", "hunter2")
+
+    with pytest.raises(ValueError, match="not strong enough"):
+        s3_log_extraction.utils.get_key()
+
+
+@pytest.mark.ai_generated
+def test_get_key_returns_valid_deterministic_fernet_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_key should return a valid Fernet key that is stable across calls for the same password."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+    monkeypatch.delenv("S3_LOG_EXTRACTION_SALT", raising=False)
+
+    key = s3_log_extraction.utils.get_key()
+
+    # Must be accepted by Fernet, which validates the length and base64url format.
+    cryptography.fernet.Fernet(key=key)
+    # Determinism is required so that data encrypted in one run can be decrypted in another.
+    assert s3_log_extraction.utils.get_key() == key
+
+
+@pytest.mark.ai_generated
+def test_get_key_salt_override_changes_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Overriding the salt should produce a different key for the same password."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+
+    monkeypatch.delenv("S3_LOG_EXTRACTION_SALT", raising=False)
+    default_salt_key = s3_log_extraction.utils.get_key()
+
+    monkeypatch.setenv("S3_LOG_EXTRACTION_SALT", "a-different-salt-value")
+    custom_salt_key = s3_log_extraction.utils.get_key()
+
+    assert (default_salt_key != custom_salt_key) is True
+
+
+@pytest.mark.ai_generated
+def test_encrypt_decrypt_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bytes encrypted with a strong password should decrypt back to the original."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+
+    data = b"192.0.2.1\n198.51.100.2\n"
+    encrypted_data = s3_log_extraction.utils.encrypt_bytes(data=data)
+
+    assert (encrypted_data != data) is True
+    assert s3_log_extraction.utils.decrypt_bytes(encrypted_data=encrypted_data) == data
+
+
+@pytest.mark.ai_generated
+def test_write_then_read_encrypted_file_round_trip(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Text written with encryption should be unreadable as plaintext but recoverable via decryption."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+
+    file_path = tmp_path / "ips.txt"
+    text = "192.0.2.1\n198.51.100.2\n"
+
+    s3_log_extraction.utils.write_text_to_file(file_path=file_path, text=text, use_encryption=True)
+
+    # The on-disk bytes should be ciphertext, not the original plaintext.
+    assert (file_path.read_bytes() != text.encode(encoding="utf-8")) is True
+    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=True) == text
+
+
+@pytest.mark.ai_generated
+def test_read_empty_encrypted_file_returns_empty_string(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reading an empty file with encryption enabled should return an empty string rather than error."""
+    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+
+    file_path = tmp_path / "empty.txt"
+    file_path.write_bytes(b"")
+
+    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=True) == ""
+
+
+@pytest.mark.ai_generated
+def test_write_then_read_plaintext_file_round_trip(tmp_path: pathlib.Path) -> None:
+    """With encryption disabled, content should be written and read back as plaintext."""
+    file_path = tmp_path / "plain.txt"
+    text = "192.0.2.1\n"
+
+    s3_log_extraction.utils.write_text_to_file(file_path=file_path, text=text, use_encryption=False)
+
+    assert file_path.read_text() == text
+    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=False) == text

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -15,139 +15,111 @@ _STRONG_PASSWORD = secrets.token_urlsafe(32)
 
 @pytest.mark.ai_generated
 @pytest.mark.parametrize(
-    "generated_password",
+    "password, is_strong",
     [
-        secrets.token_urlsafe(32),
-        secrets.token_urlsafe(16),
-        secrets.token_hex(16),
-        uuid.uuid4().hex,
+        (secrets.token_urlsafe(32), True),
+        (secrets.token_urlsafe(16), True),
+        (secrets.token_hex(16), True),
+        (uuid.uuid4().hex, True),
+        ("café-" + secrets.token_urlsafe(24), True),  # strong, and includes a non-ASCII character
+        ("hunter2", False),  # too short
+        ("Password123!", False),  # too short (12 characters)
+        ("aaaaaaaaaaaaaaaaaaaa", False),  # long but only one distinct character
+        ("12345678901234567890", False),  # long but only digits, so low entropy
+        ("", False),  # empty password has zero estimated entropy
     ],
 )
-def test_validate_password_strength_accepts_generated_secrets(generated_password: str) -> None:
-    """Randomly generated high-entropy secrets should pass validation without raising."""
-    s3_log_extraction.utils.validate_password_strength(generated_password)
+def test_validate_password_strength(password: str, is_strong: bool) -> None:
+    """Generated secrets pass validation while weak human-chosen passwords are rejected."""
+    if is_strong:
+        s3_log_extraction.utils.validate_password_strength(password)
+        return
 
+    with pytest.raises(ValueError, match="not strong enough") as error_info:
+        s3_log_extraction.utils.validate_password_strength(password)
 
-@pytest.mark.ai_generated
-@pytest.mark.parametrize(
-    "weak_password",
-    [
-        "hunter2",  # too short
-        "Password123!",  # too short (12 characters)
-        "aaaaaaaaaaaaaaaaaaaa",  # long but only one distinct character
-        "12345678901234567890",  # long but only digits, so low entropy
-    ],
-)
-def test_validate_password_strength_rejects_weak_passwords(weak_password: str) -> None:
-    """Short or low-variety human-chosen passwords should be rejected."""
-    with pytest.raises(ValueError, match="not strong enough"):
-        s3_log_extraction.utils.validate_password_strength(weak_password)
-
-
-@pytest.mark.ai_generated
-def test_validate_password_strength_error_mentions_env_var_and_recommendation() -> None:
-    """The error message should name the environment variable and suggest a generated secret."""
-    with pytest.raises(ValueError) as error_info:
-        s3_log_extraction.utils.validate_password_strength("short")
-
+    # The error should name the environment variable and recommend a generated secret.
     message = str(error_info.value)
     assert ("S3_LOG_EXTRACTION_PASSWORD" in message) is True
     assert ("secrets.token_urlsafe" in message) is True
 
 
 @pytest.mark.ai_generated
-def test_get_key_requires_environment_variable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_key should raise EnvironmentError when the password variable is unset."""
-    monkeypatch.delenv("S3_LOG_EXTRACTION_PASSWORD", raising=False)
-
-    with pytest.raises(EnvironmentError, match="S3_LOG_EXTRACTION_PASSWORD"):
-        s3_log_extraction.utils.get_key()
-
-
-@pytest.mark.ai_generated
-def test_get_key_rejects_weak_password(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_key should refuse to derive a key from a weak password before any encryption happens."""
-    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", "hunter2")
-
-    with pytest.raises(ValueError, match="not strong enough"):
-        s3_log_extraction.utils.get_key()
-
-
-@pytest.mark.ai_generated
-def test_get_key_returns_valid_deterministic_fernet_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """get_key should return a valid Fernet key that is stable across calls for the same password."""
-    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+@pytest.mark.parametrize(
+    "password, expected_error",
+    [
+        (None, EnvironmentError),  # environment variable unset
+        ("hunter2", ValueError),  # password too weak
+        (_STRONG_PASSWORD, None),  # accepted
+    ],
+)
+def test_get_key_validates_before_deriving(
+    password: str | None, expected_error: type[Exception] | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """get_key requires the env var, rejects weak passwords, and otherwise returns a deterministic Fernet key."""
     monkeypatch.delenv("S3_LOG_EXTRACTION_SALT", raising=False)
+    if password is None:
+        monkeypatch.delenv("S3_LOG_EXTRACTION_PASSWORD", raising=False)
+    else:
+        monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", password)
+
+    if expected_error is not None:
+        with pytest.raises(expected_error):
+            s3_log_extraction.utils.get_key()
+        return
 
     key = s3_log_extraction.utils.get_key()
-
-    # Must be accepted by Fernet, which validates the length and base64url format.
-    cryptography.fernet.Fernet(key=key)
+    cryptography.fernet.Fernet(key=key)  # Validates the length and base64url format.
     # Determinism is required so that data encrypted in one run can be decrypted in another.
     assert s3_log_extraction.utils.get_key() == key
 
 
 @pytest.mark.ai_generated
 def test_get_key_salt_override_changes_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Overriding the salt should produce a different key for the same password."""
+    """Overriding the salt produces a different key for the same password."""
     monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
 
     monkeypatch.delenv("S3_LOG_EXTRACTION_SALT", raising=False)
     default_salt_key = s3_log_extraction.utils.get_key()
 
     monkeypatch.setenv("S3_LOG_EXTRACTION_SALT", "a-different-salt-value")
-    custom_salt_key = s3_log_extraction.utils.get_key()
-
-    assert (default_salt_key != custom_salt_key) is True
+    assert (s3_log_extraction.utils.get_key() != default_salt_key) is True
 
 
 @pytest.mark.ai_generated
-def test_encrypt_decrypt_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Bytes encrypted with a strong password should decrypt back to the original."""
+@pytest.mark.parametrize("data", [b"192.0.2.1\n198.51.100.2\n", b""])
+def test_encrypt_decrypt_round_trip(data: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bytes encrypted with a strong password decrypt back to the original."""
     monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
 
-    data = b"192.0.2.1\n198.51.100.2\n"
     encrypted_data = s3_log_extraction.utils.encrypt_bytes(data=data)
 
-    assert (encrypted_data != data) is True
     assert s3_log_extraction.utils.decrypt_bytes(encrypted_data=encrypted_data) == data
 
 
 @pytest.mark.ai_generated
-def test_write_then_read_encrypted_file_round_trip(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Text written with encryption should be unreadable as plaintext but recoverable via decryption."""
-    monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
-
-    file_path = tmp_path / "ips.txt"
-    text = "192.0.2.1\n198.51.100.2\n"
-
-    s3_log_extraction.utils.write_text_to_file(file_path=file_path, text=text, use_encryption=True)
-
-    # The on-disk bytes should be ciphertext, not the original plaintext.
-    assert (file_path.read_bytes() != text.encode(encoding="utf-8")) is True
-    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=True) == text
-
-
-@pytest.mark.ai_generated
-def test_read_empty_encrypted_file_returns_empty_string(
-    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    "text, use_encryption",
+    [
+        ("192.0.2.1\n198.51.100.2\n", True),  # encrypted round trip
+        ("192.0.2.1\n", False),  # plaintext round trip
+        ("", True),  # empty on-disk file should decrypt to an empty string
+    ],
+)
+def test_file_round_trip(
+    text: str, use_encryption: bool, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Reading an empty file with encryption enabled should return an empty string rather than error."""
+    """Text written to a file is recovered on read, and encrypted content is never stored as plaintext."""
     monkeypatch.setenv("S3_LOG_EXTRACTION_PASSWORD", _STRONG_PASSWORD)
+    file_path = tmp_path / "ips.txt"
 
-    file_path = tmp_path / "empty.txt"
-    file_path.write_bytes(b"")
+    if text == "":
+        # Represents an empty cache file, exercising the empty-file early return on read.
+        file_path.write_bytes(b"")
+    else:
+        s3_log_extraction.utils.write_text_to_file(file_path=file_path, text=text, use_encryption=use_encryption)
+        if use_encryption:
+            # The on-disk bytes should be ciphertext, not the original plaintext.
+            assert (file_path.read_bytes() != text.encode(encoding="utf-8")) is True
 
-    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=True) == ""
-
-
-@pytest.mark.ai_generated
-def test_write_then_read_plaintext_file_round_trip(tmp_path: pathlib.Path) -> None:
-    """With encryption disabled, content should be written and read back as plaintext."""
-    file_path = tmp_path / "plain.txt"
-    text = "192.0.2.1\n"
-
-    s3_log_extraction.utils.write_text_to_file(file_path=file_path, text=text, use_encryption=False)
-
-    assert file_path.read_text() == text
-    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=False) == text
+    assert s3_log_extraction.utils.read_text_from_file(file_path=file_path, use_encryption=use_encryption) == text


### PR DESCRIPTION
## Summary
Improved the encryption key derivation mechanism by replacing a simple SHA256 hash with PBKDF2-HMAC-SHA256, a deliberately expensive key derivation function that provides better resistance to brute-force attacks.

## Key Changes
- Replaced `hashlib.sha256()` with `PBKDF2HMAC` using SHA256 algorithm
- Added configurable salt support via `S3_LOG_EXTRACTION_SALT` environment variable with a stable default salt (`b"s3_log_extraction"`)
- Set PBKDF2 iterations to 600,000 following OWASP recommendations for PBKDF2-HMAC-SHA256
- Updated docstring to document the new key derivation approach and environment variables

## Implementation Details
- The salt is deterministic by default to ensure encrypted data can be decrypted across different runs
- The salt can be overridden via the `S3_LOG_EXTRACTION_SALT` environment variable for stronger separation when needed
- The key derivation function is intentionally expensive (600k iterations) to make brute-force attacks computationally infeasible
- The derived key length remains 32 bytes, maintaining compatibility with the Fernet encryption scheme

https://claude.ai/code/session_01BFG3smk8JoaTouHg69j7Ja