### PR TITLE
Exclude cloud service and VPN IPs from requester count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🚀 Enhancement
 
+- Excluded known cloud service and VPN IPs (GitHub, AWS, GCP, VPN) from the `number_of_requesters` count reported in per-dataset, archive, and total summaries. ([#291](https://github.com/dandi/s3-log-extraction/pull/291))
 - Strengthened encryption key derivation. The `S3_LOG_EXTRACTION_PASSWORD` value now passes through PBKDF2-HMAC-SHA256 instead of a single SHA-256 pass, which resists brute-force attacks. Weak passwords are also rejected before any encryption runs. A public `validate_password_strength` helper was added. ([#283](https://github.com/dandi/s3-log-extraction/pull/283))
 - Added the `s3logextraction stats` CLI command and the `get_log_bucket_stats` API helper for summarizing S3 inventory. ([#224](https://github.com/dandi/s3-log-extraction/pull/224))
 - Extended the `s3logextraction stats` command and added a `get_ip_stats` API helper to report IP address classification statistics from the IP cache. Every cached IP is binned into one of seven categories (determined, missing, unknown, bogon, VPN, cloud service, GitHub) with counts and percentages. The command also gains `--cache` and `--encryption` flags. ([#274](https://github.com/dandi/s3-log-extraction/pull/274))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug Fix
 
+- Narrowed `is_cloud_service_or_vpn_label` to only match genuine cloud/VPN service labels (`"GitHub"`, `"VPN"`, `"AWS/…"`, `"GCP/…"`). It previously also matched unresolved-location labels (`"unknown"`, `"undetermined"`, `"missing"`, `"bogon"`), which caused real requesters whose IPs could not be geolocated to be silently dropped from `number_of_requesters`. ([#291](https://github.com/dandi/s3-log-extraction/pull/291))
 - Fixed the IPInfo quota-exceeded fallback so daily remote tests return `undetermined` instead of crashing on Python 3.14 when a warning is emitted. ([#273](https://github.com/dandi/s3-log-extraction/pull/273))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.7"
+version="1.10.8"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.6"
+version="1.10.7"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/s3_log_extraction/ip_utils/__init__.py
+++ b/src/s3_log_extraction/ip_utils/__init__.py
@@ -2,10 +2,11 @@ from ._update_ip_to_region_codes import update_ip_to_region_codes
 from ._ip_cache import load_ip_cache, write_ip_cache
 from ._refresh_ip_to_region_codes import refresh_ip_to_region_codes
 from ._update_region_code_coordinates import update_region_code_coordinates
-from ._globals import EXCLUDED_REGION_LABELS
+from ._globals import EXCLUDED_REGION_LABELS, is_cloud_service_or_vpn_label
 
 __all__ = [
     "EXCLUDED_REGION_LABELS",
+    "is_cloud_service_or_vpn_label",
     "load_ip_cache",
     "write_ip_cache",
     "refresh_ip_to_region_codes",

--- a/src/s3_log_extraction/ip_utils/_globals.py
+++ b/src/s3_log_extraction/ip_utils/_globals.py
@@ -8,10 +8,14 @@ def is_cloud_service_or_vpn_label(region_label: str) -> bool:
     Determine whether a region/service label (as produced by ``ip_to_region``) refers to a
     known cloud service or VPN provider (e.g. ``"GitHub"``, ``"AWS/us-east-1"``, ``"GCP/us-central1"``,
     ``"VPN"``) rather than a genuine geographic requester location.
+
+    Note that unresolved labels such as ``"unknown"``, ``"undetermined"``, ``"missing"``, or ``"bogon"``
+    are NOT considered cloud service or VPN labels here; they simply mean the requester's location could
+    not be determined, not that the requester is known cloud/VPN infrastructure.
     """
-    if region_label in EXCLUDED_REGION_LABELS:
+    if region_label in ("VPN", "GitHub"):
         return True
-    return any(region_label.startswith(f"{service_name}/") for service_name in _KNOWN_SERVICES)
+    return any(region_label.startswith(f"{service_name}/") for service_name in ("AWS", "GCP"))
 
 
 _DEFAULT_REGION_CODES_TO_COORDINATES = {

--- a/src/s3_log_extraction/ip_utils/_globals.py
+++ b/src/s3_log_extraction/ip_utils/_globals.py
@@ -13,9 +13,9 @@ def is_cloud_service_or_vpn_label(region_label: str) -> bool:
     are NOT considered cloud service or VPN labels here; they simply mean the requester's location could
     not be determined, not that the requester is known cloud/VPN infrastructure.
     """
-    if region_label in ("VPN", "GitHub"):
-        return True
-    return any(region_label.startswith(f"{service_name}/") for service_name in ("AWS", "GCP"))
+    return any(
+        region_label == service_name or region_label.startswith(f"{service_name}/") for service_name in _KNOWN_SERVICES
+    )
 
 
 _DEFAULT_REGION_CODES_TO_COORDINATES = {

--- a/src/s3_log_extraction/ip_utils/_globals.py
+++ b/src/s3_log_extraction/ip_utils/_globals.py
@@ -2,6 +2,17 @@ _KNOWN_SERVICES = ("GitHub", "AWS", "GCP", "VPN")  # Azure has problems; see _ip
 
 EXCLUDED_REGION_LABELS = frozenset(["VPN", "GitHub", "unknown", "undetermined", "missing", "bogon"])
 
+
+def is_cloud_service_or_vpn_label(region_label: str) -> bool:
+    """
+    Determine whether a region/service label (as produced by ``ip_to_region``) refers to a
+    known cloud service or VPN provider (e.g. ``"GitHub"``, ``"AWS/us-east-1"``, ``"GCP/us-central1"``,
+    ``"VPN"``) rather than a genuine geographic requester location.
+    """
+    if region_label in EXCLUDED_REGION_LABELS:
+        return True
+    return any(region_label.startswith(f"{service_name}/") for service_name in _KNOWN_SERVICES)
+
 _DEFAULT_REGION_CODES_TO_COORDINATES = {
     # Included for testing/demo purposes
     "AWS/us-east-2": {"latitude": 39.9612, "longitude": -82.9988},

--- a/src/s3_log_extraction/ip_utils/_globals.py
+++ b/src/s3_log_extraction/ip_utils/_globals.py
@@ -13,6 +13,7 @@ def is_cloud_service_or_vpn_label(region_label: str) -> bool:
         return True
     return any(region_label.startswith(f"{service_name}/") for service_name in _KNOWN_SERVICES)
 
+
 _DEFAULT_REGION_CODES_TO_COORDINATES = {
     # Included for testing/demo purposes
     "AWS/us-east-2": {"latitude": 39.9612, "longitude": -82.9988},

--- a/src/s3_log_extraction/summarize/_generate_summaries.py
+++ b/src/s3_log_extraction/summarize/_generate_summaries.py
@@ -7,6 +7,7 @@ import tqdm
 
 from ..config import get_cache_directory, get_cache_subdirectory
 from ..ip_utils import load_ip_cache
+from ..ip_utils._globals import is_cloud_service_or_vpn_label
 from ..ip_utils._ip_utils import _read_ips_from_file
 
 
@@ -49,7 +50,11 @@ def _privacy_round_request_download_columns(
     return summary_table
 
 
-def _collect_unique_ips(asset_directories: list[pathlib.Path], use_encryption: bool = True) -> set[str]:
+def _collect_unique_ips(
+    asset_directories: list[pathlib.Path],
+    use_encryption: bool = True,
+    ip_to_region: dict[str, str] | None = None,
+) -> set[str]:
     """
     Collect all unique IP addresses across the given asset directories.
 
@@ -60,18 +65,25 @@ def _collect_unique_ips(asset_directories: list[pathlib.Path], use_encryption: b
     use_encryption : bool
         If ``True`` (default), ``ips.txt`` files are decrypted before reading.
         If ``False``, files are read as plaintext.
+    ip_to_region : dict of str to str, optional
+        Mapping of IP address to region/service label, used to exclude known cloud
+        service IPs (e.g. GitHub, AWS, GCP, VPN) from the collected set. If not
+        provided, no exclusion is applied.
 
     Returns
     -------
     set of str
-        The set of unique IP addresses found across all ``ips.txt`` files.
+        The set of unique IP addresses found across all ``ips.txt`` files, excluding
+        any IPs classified as a known cloud service or VPN.
     """
+    ip_to_region = ip_to_region or {}
     unique_ips: set[str] = set()
     for asset_directory in asset_directories:
         full_ips_file_path = asset_directory / "ips.txt"
         if not full_ips_file_path.exists():
             continue
-        unique_ips.update(_read_ips_from_file(file_path=full_ips_file_path, use_encryption=use_encryption))
+        ips = _read_ips_from_file(file_path=full_ips_file_path, use_encryption=use_encryption)
+        unique_ips.update(ip for ip in ips if not is_cloud_service_or_vpn_label(ip_to_region.get(ip, "")))
     return unique_ips
 
 
@@ -79,6 +91,7 @@ def _summarize_dataset_requester_count(
     *,
     asset_directories: list[pathlib.Path],
     summary_file_path: pathlib.Path,
+    ip_to_region: dict[str, str],
     modulo: int = 20,
     minimum: int = 50,
     use_encryption: bool = True,
@@ -87,8 +100,9 @@ def _summarize_dataset_requester_count(
     Compute and save the privacy-rounded unique requester count for a dataset.
 
     Reads all ``ips.txt`` files from the given asset directories, counts the
-    number of unique IP addresses across the entire dataset, rounds the result via
-    :func:`_round_requester_count`, and writes the value to ``summary_file_path``.
+    number of unique IP addresses across the entire dataset (excluding known cloud
+    service and VPN IPs), rounds the result via :func:`_round_requester_count`, and
+    writes the value to ``summary_file_path``.
 
     Parameters
     ----------
@@ -96,6 +110,9 @@ def _summarize_dataset_requester_count(
         Paths to the per-asset extraction directories containing ``ips.txt`` files.
     summary_file_path : pathlib.Path
         Destination file where the rounded count (as a string) will be written.
+    ip_to_region : dict of str to str
+        Mapping of IP address to region/service label, used to exclude known cloud
+        service IPs (e.g. GitHub, AWS, GCP, VPN) from the requester count.
     modulo : int, optional
         Granularity for rounding.  Default is ``20``.
     minimum : int, optional
@@ -105,7 +122,9 @@ def _summarize_dataset_requester_count(
         If ``True`` (default), ``ips.txt`` files are decrypted before reading.
         If ``False``, files are read as plaintext.
     """
-    unique_ips = _collect_unique_ips(asset_directories=asset_directories, use_encryption=use_encryption)
+    unique_ips = _collect_unique_ips(
+        asset_directories=asset_directories, use_encryption=use_encryption, ip_to_region=ip_to_region
+    )
 
     if not unique_ips:
         return
@@ -184,7 +203,9 @@ def generate_summaries(
         )
 
         all_archive_unique_ips.update(
-            _collect_unique_ips(asset_directories=asset_directories, use_encryption=use_encryption)
+            _collect_unique_ips(
+                asset_directories=asset_directories, use_encryption=use_encryption, ip_to_region=ip_to_region
+            )
         )
     if all_archive_unique_ips:
         archive_directory = summary_directory / "archive"
@@ -224,6 +245,7 @@ def _summarize_dataset(
     _summarize_dataset_requester_count(
         asset_directories=asset_directories,
         summary_file_path=summary_directory / dataset_id / "requester_count.tsv",
+        ip_to_region=ip_to_region,
         minimum=privacy_threshold_minimum,
         use_encryption=use_encryption,
     )

--- a/tests/test_generic_summaries.py
+++ b/tests/test_generic_summaries.py
@@ -370,13 +370,39 @@ def test_round_requester_count(count: int, modulo: int, minimum: int, expected: 
 
 
 @pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    ("region_label", "expected"),
+    [
+        # Genuine known cloud service / VPN labels are excluded
+        ("GitHub", True),
+        ("VPN", True),
+        ("AWS/us-east-1", True),
+        ("GCP/us-central1", True),
+        # Unresolved-location labels are NOT cloud/VPN labels; a real requester's IP
+        # simply failed to geolocate (rate limit, quota exceeded, obscure IP, etc.)
+        ("unknown", False),
+        ("undetermined", False),
+        ("missing", False),
+        ("bogon", False),
+        # Genuine geographic labels are not excluded
+        ("US/California", False),
+    ],
+)
+def test_is_cloud_service_or_vpn_label(region_label: str, expected: bool) -> None:
+    """Only genuine cloud/VPN service labels are excluded; unresolved-location labels are not."""
+    from s3_log_extraction.ip_utils import is_cloud_service_or_vpn_label
+
+    assert is_cloud_service_or_vpn_label(region_label) == expected
+
+
+@pytest.mark.ai_generated
 def test_collect_unique_ips_excludes_known_cloud_service_ips(tmpdir: py.path.local) -> None:
-    """Known cloud service/VPN IPs (per EXCLUDED_REGION_LABELS) are excluded from the requester count."""
+    """Known cloud service/VPN IPs are excluded from the requester count, but unresolved-location IPs are not."""
     from s3_log_extraction.summarize._generate_summaries import _collect_unique_ips
 
     asset_dir = pathlib.Path(tmpdir) / "asset"
     asset_dir.mkdir(parents=True, exist_ok=True)
-    (asset_dir / "ips.txt").write_text("1.2.3.4\n5.6.7.8\n9.10.11.12\n13.14.15.16\n17.18.19.20\n")
+    (asset_dir / "ips.txt").write_text("1.2.3.4\n5.6.7.8\n9.10.11.12\n13.14.15.16\n17.18.19.20\n21.22.23.24\n")
 
     ip_to_region = {
         "1.2.3.4": "US/California",
@@ -384,11 +410,12 @@ def test_collect_unique_ips_excludes_known_cloud_service_ips(tmpdir: py.path.loc
         "9.10.11.12": "AWS/us-east-1",
         "13.14.15.16": "VPN",
         "17.18.19.20": "bogon",
+        "21.22.23.24": "unknown",
     }
 
     unique_ips = _collect_unique_ips(asset_directories=[asset_dir], use_encryption=False, ip_to_region=ip_to_region)
 
-    assert unique_ips == {"1.2.3.4"}
+    assert unique_ips == {"1.2.3.4", "17.18.19.20", "21.22.23.24"}
 
 
 @pytest.mark.ai_generated

--- a/tests/test_generic_summaries.py
+++ b/tests/test_generic_summaries.py
@@ -367,3 +367,50 @@ def test_round_requester_count(count: int, modulo: int, minimum: int, expected: 
     from s3_log_extraction.summarize._generate_summaries import _round_requester_count
 
     assert _round_requester_count(count=count, modulo=modulo, minimum=minimum) == expected
+
+
+@pytest.mark.ai_generated
+def test_collect_unique_ips_excludes_known_cloud_service_ips(tmpdir: py.path.local) -> None:
+    """Known cloud service/VPN IPs (per EXCLUDED_REGION_LABELS) are excluded from the requester count."""
+    from s3_log_extraction.summarize._generate_summaries import _collect_unique_ips
+
+    asset_dir = pathlib.Path(tmpdir) / "asset"
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    (asset_dir / "ips.txt").write_text("1.2.3.4\n5.6.7.8\n9.10.11.12\n13.14.15.16\n17.18.19.20\n")
+
+    ip_to_region = {
+        "1.2.3.4": "US/California",
+        "5.6.7.8": "GitHub",
+        "9.10.11.12": "AWS/us-east-1",
+        "13.14.15.16": "VPN",
+        "17.18.19.20": "bogon",
+    }
+
+    unique_ips = _collect_unique_ips(asset_directories=[asset_dir], use_encryption=False, ip_to_region=ip_to_region)
+
+    assert unique_ips == {"1.2.3.4"}
+
+
+@pytest.mark.ai_generated
+def test_summarize_dataset_requester_count_excludes_known_cloud_service_ips(tmpdir: py.path.local) -> None:
+    """The rounded requester count written to disk excludes known cloud service/VPN IPs."""
+    from s3_log_extraction.summarize._generate_summaries import _summarize_dataset_requester_count
+
+    asset_dir = pathlib.Path(tmpdir) / "asset"
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    real_ips = [f"10.0.0.{index}" for index in range(60)]
+    cloud_ips = [f"192.168.0.{index}" for index in range(60)]
+    (asset_dir / "ips.txt").write_text("\n".join(real_ips + cloud_ips))
+
+    ip_to_region = {ip: "US/California" for ip in real_ips} | {ip: "GitHub" for ip in cloud_ips}
+
+    summary_file_path = pathlib.Path(tmpdir) / "requester_count.tsv"
+    _summarize_dataset_requester_count(
+        asset_directories=[asset_dir],
+        summary_file_path=summary_file_path,
+        ip_to_region=ip_to_region,
+        minimum=50,
+        use_encryption=False,
+    )
+
+    assert summary_file_path.read_text().strip() == "60"


### PR DESCRIPTION
## Summary
This PR adds functionality to exclude known cloud service and VPN IP addresses from the requester count calculations in S3 log summaries. This improves the accuracy of unique requester metrics by filtering out non-human traffic from services like GitHub, AWS, GCP, and VPN providers.

## Key Changes
- **New utility function**: Added `is_cloud_service_or_vpn_label()` in `ip_utils/_globals.py` to determine if a region/service label refers to a known cloud service or VPN provider
- **Enhanced IP collection**: Modified `_collect_unique_ips()` to accept an optional `ip_to_region` mapping and filter out IPs classified as cloud services or VPNs
- **Updated requester count function**: Modified `_summarize_dataset_requester_count()` to accept and pass through the `ip_to_region` mapping for filtering
- **Updated callers**: Modified `generate_summaries()` and `_summarize_dataset()` to pass the `ip_to_region` mapping to the IP collection functions
- **Exported new function**: Added `is_cloud_service_or_vpn_label` to the public API in `ip_utils/__init__.py`
- **Comprehensive tests**: Added two new test cases to verify that cloud service IPs are properly excluded from both the IP collection and the final requester count

## Implementation Details
- The filtering leverages the existing `EXCLUDED_REGION_LABELS` frozenset and checks for known service prefixes (e.g., "AWS/", "GCP/")
- The `ip_to_region` parameter is optional in `_collect_unique_ips()` to maintain backward compatibility
- Tests are marked with `@pytest.mark.ai_generated` to indicate their origin

https://claude.ai/code/session_01S3e1TfUAHBiYWp6Kc1XtVZ