### PR TITLE
Handle API quota exhaustion gracefully in IP geolocation workflows

### DIFF
--- a/.github/workflows/version_check.yml
+++ b/.github/workflows/version_check.yml
@@ -1,0 +1,33 @@
+name: Version Check
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "pyproject.toml"
+
+permissions: {}
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        run: |
+          git show origin/${{ github.base_ref }}:pyproject.toml > /tmp/base_pyproject.toml
+          PR_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])")
+          BASE_VERSION=$(python3 -c "import pathlib, tomllib; print(tomllib.loads(pathlib.Path('/tmp/base_pyproject.toml').read_text())['project']['version'])")
+          echo "Base version: $BASE_VERSION"
+          echo "PR version:   $PR_VERSION"
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "::error::Version has not been bumped. Please update the version in pyproject.toml."
+            exit 1
+          fi
+          echo "Version bumped from $BASE_VERSION to $PR_VERSION ✓"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### 🐛 Bug Fix
+
+- Fixed the daily IP cache update workflows so that an exhausted IPInfo (or OpenCage) API quota no longer wastes hours on doomed requests or crashes the run. `update ip regions` now halts at the first quota error and leaves unprocessed IPs uncached for retry on the next run, instead of permanently caching them as `undetermined`. `update ip coordinates` now saves partial progress and exits cleanly instead of raising an unhandled `RequestQuotaExceededError`. `update ip refresh` now halts early without overwriting existing cache entries. ([#292](https://github.com/dandi/s3-log-extraction/pull/292))
+
 ## v1.10.8
 
 ### 🚀 Enhancement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug Fix
 
-- Fixed the daily IP cache update workflows so that an exhausted IPInfo (or OpenCage) API quota no longer wastes hours on doomed requests or crashes the run. `update ip regions` now halts at the first quota error and leaves unprocessed IPs uncached for retry on the next run, instead of permanently caching them as `undetermined`. `update ip coordinates` now saves partial progress and exits cleanly instead of raising an unhandled `RequestQuotaExceededError`. `update ip refresh` now halts early without overwriting existing cache entries. ([#292](https://github.com/dandi/s3-log-extraction/pull/292))
+- Fixed the daily IP cache update workflows so that an exhausted IPInfo (or OpenCage) API quota no longer wastes hours on doomed requests or crashes the run. `update ip regions` now halts at the first quota error and leaves unprocessed IPs uncached for retry on the next run, instead of permanently caching them as `undetermined`. `update ip coordinates` now saves partial progress and exits cleanly instead of raising an unhandled `RequestQuotaExceededError`. `update ip refresh` now halts early without overwriting existing cache entries. The daily remote tests skip (rather than fail) when the quota is exhausted, since live lookups cannot be validated in that state. ([#292](https://github.com/dandi/s3-log-extraction/pull/292))
 
 ## v1.10.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### 🏠 Internal
+
+- Added a `Version Check` CI workflow that fails pull requests which modify `src/` or `pyproject.toml` without bumping the package version. ([#292](https://github.com/dandi/s3-log-extraction/pull/292))
+
 ### 🐛 Bug Fix
 
 - Fixed the daily IP cache update workflows so that an exhausted IPInfo (or OpenCage) API quota no longer wastes hours on doomed requests or crashes the run. `update ip regions` now halts at the first quota error and leaves unprocessed IPs uncached for retry on the next run, instead of permanently caching them as `undetermined`. `update ip coordinates` now saves partial progress and exits cleanly instead of raising an unhandled `RequestQuotaExceededError`. `update ip refresh` now halts early without overwriting existing cache entries. ([#292](https://github.com/dandi/s3-log-extraction/pull/292))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = ["src/s3_log_extraction"]
 
 [project]
 name = "s3-log-extraction"
-version="1.10.8"
+version="1.10.9"
 authors = [
   { name="Cody Baker", email="cody.c.baker.phd@gmail.com" },
 ]

--- a/src/s3_log_extraction/ip_utils/_refresh_ip_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_refresh_ip_to_region_codes.py
@@ -2,6 +2,7 @@ import datetime
 import math
 import os
 import pathlib
+import warnings
 
 import yaml
 
@@ -75,7 +76,18 @@ def refresh_ip_to_region_codes(
     changes: dict[str, dict[str, str]] = {}
     for ip_address in ips_to_refresh:
         old_region = ip_to_region[ip_address]
-        new_region = _get_region_code_from_ip_address(ip_address=ip_address, ipinfo_handler=ipinfo_handler)
+        try:
+            new_region = _get_region_code_from_ip_address(ip_address=ip_address, ipinfo_handler=ipinfo_handler)
+        except ipinfo.exceptions.RequestQuotaExceededError:
+            warnings.warn(
+                message=(
+                    "IPInfo API request quota exceeded. Halting the refresh early; "
+                    "existing cache entries are left unchanged."
+                ),
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+            break
         if new_region != old_region:
             changes[ip_address] = {"old": old_region, "new": new_region}
             ip_to_region[ip_address] = new_region

--- a/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
+++ b/src/s3_log_extraction/ip_utils/_update_ip_to_region_codes.py
@@ -92,7 +92,18 @@ def update_ip_to_region_codes(
             position=1,
             leave=False,
         ):
-            region_code = _get_region_code_from_ip_address(ip_address=ip_address, ipinfo_handler=ipinfo_handler)
+            try:
+                region_code = _get_region_code_from_ip_address(ip_address=ip_address, ipinfo_handler=ipinfo_handler)
+            except ipinfo.exceptions.RequestQuotaExceededError:
+                warnings.warn(
+                    message=(
+                        "IPInfo API request quota exceeded. Halting the update early; "
+                        "IP addresses not yet processed will be retried on the next run."
+                    ),
+                    category=RuntimeWarning,
+                    stacklevel=2,
+                )
+                return
             ip_to_region[ip_address] = region_code
 
             write_ip_cache(
@@ -106,9 +117,7 @@ def update_ip_to_region_codes(
 def _get_region_code_from_ip_address(
     ip_address: str,
     ipinfo_handler: "ipinfo.Handler",
-) -> str | typing.Literal["undetermined", "bogon"]:
-    import ipinfo
-
+) -> str | typing.Literal["bogon"] | None:
     # Determine if the IP address belongs to GitHub, AWS, Google, or known VPNs
     # Azure not yet easily doable; keep an eye on
     # https://learn.microsoft.com/en-us/answers/questions/1410071/up-to-date-azure-public-api-to-get-azure-ip-ranges
@@ -133,31 +142,22 @@ def _get_region_code_from_ip_address(
             return region_service_string
 
     # TODO: add batching support to ipinfo requests
-    # Lines cannot be covered without testing on a real IP
-    try:  # pragma: no cover
-        timeout_in_seconds = 30
-        details = ipinfo_handler.getDetails(ip_address=ip_address, timeout=timeout_in_seconds)
+    # A quota exceeded error (`ipinfo.exceptions.RequestQuotaExceededError`) propagates to the caller,
+    # which should halt further requests since none can succeed until the quota resets.
+    timeout_in_seconds = 30
+    details = ipinfo_handler.getDetails(ip_address=ip_address, timeout=timeout_in_seconds)
 
-        country = details.details.get("country", None)
-        region = details.details.get("region", None)
+    country = details.details.get("country", None)
+    region = details.details.get("region", None)
 
-        match (country is None, region is None):
-            case (True, True):
-                region_string = "bogon" if details.details.get("bogon", False) is True else None
-            case (True, False):
-                region_string = region
-            case (False, True):
-                region_string = country
-            case (False, False):
-                region_string = f"{country}/{region}"
+    match (country is None, region is None):
+        case (True, True):
+            region_string = "bogon" if details.details.get("bogon", False) is True else None
+        case (True, False):
+            region_string = region
+        case (False, True):
+            region_string = country
+        case (False, False):
+            region_string = f"{country}/{region}"
 
-        return region_string
-    except ipinfo.exceptions.RequestQuotaExceededError:  # pragma: no cover
-        warnings.warn(
-            message="IPInfo API request quota exceeded. Returning 'undetermined' value.",
-            category=RuntimeWarning,
-            stacklevel=2,
-        )
-        return "undetermined"
-
-    return "unknown"
+    return region_string

--- a/src/s3_log_extraction/ip_utils/_update_region_code_coordinates.py
+++ b/src/s3_log_extraction/ip_utils/_update_region_code_coordinates.py
@@ -1,5 +1,6 @@
 import os
 import pathlib
+import warnings
 
 import natsort
 import tqdm
@@ -67,6 +68,10 @@ def update_region_code_coordinates(
     ip_to_region = load_ip_cache(
         cache_type="ip_to_region", cache_directory=cache_directory, use_encryption=use_encryption
     )
+    quota_exceeded_exceptions = (
+        ipinfo.exceptions.RequestQuotaExceededError,
+        opencage.geocoder.RateLimitExceededError,
+    )
     region_codes_to_update = set(ip_to_region.values()) - set(region_codes_to_coordinates.keys())
     opencage_failures = []
     for country_and_region_code in tqdm.tqdm(
@@ -80,13 +85,24 @@ def update_region_code_coordinates(
         if country_and_region_code == "bogon":
             continue
 
-        coordinates = _get_coordinates_from_region_code(
-            country_and_region_code=country_and_region_code,
-            ipinfo_client=ipinfo_client,
-            opencage_client=opencage_client,
-            service_coordinates=service_coordinates,
-            opencage_failures=opencage_failures,
-        )
+        try:
+            coordinates = _get_coordinates_from_region_code(
+                country_and_region_code=country_and_region_code,
+                ipinfo_client=ipinfo_client,
+                opencage_client=opencage_client,
+                service_coordinates=service_coordinates,
+                opencage_failures=opencage_failures,
+            )
+        except quota_exceeded_exceptions:
+            warnings.warn(
+                message=(
+                    "API request quota exceeded. Halting the coordinates update early; "
+                    "progress so far is saved and remaining region codes will be retried on the next run."
+                ),
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+            break
 
         if coordinates is not None:
             region_codes_to_coordinates[country_and_region_code] = coordinates

--- a/tests/test_ip_utils.py
+++ b/tests/test_ip_utils.py
@@ -228,6 +228,49 @@ def test_update_ip_to_region_codes_saves_progress_before_quota_exceeded(
 
 
 @pytest.mark.ai_generated
+@pytest.mark.parametrize(
+    ("details", "expected_region"),
+    [
+        ({"country": "US", "region": "California"}, "US/California"),
+        ({"country": "US"}, "US"),
+        ({"region": "California"}, "California"),
+        ({"bogon": True}, "bogon"),
+        ({}, None),
+    ],
+)
+def test_update_ip_to_region_codes_detail_combinations(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    details: dict,
+    expected_region: str | None,
+) -> None:
+    """Each combination of country/region/bogon in the IPInfo response maps to the expected region code."""
+    extraction_dir = tmp_path / "extraction" / "test_dataset" / "test_asset"
+    extraction_dir.mkdir(parents=True)
+    test_ip = "192.0.2.1"
+    (extraction_dir / "ips.txt").write_text(test_ip)
+
+    monkeypatch.setenv("IPINFO_API_KEY", "test-key-non-remote")
+
+    mock_details = unittest.mock.MagicMock()
+    mock_details.details = details
+
+    mock_handler = unittest.mock.MagicMock()
+    mock_handler.getDetails.return_value = mock_details
+
+    with unittest.mock.patch("ipinfo.getHandler", return_value=mock_handler):
+        with unittest.mock.patch(
+            "s3_log_extraction.ip_utils._update_ip_to_region_codes._get_cidr_address_ranges_and_subregions",
+            return_value=[],
+        ):
+            s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
+
+    ip_to_region_file = tmp_path / "ips" / "ip_to_region.yaml"
+    ip_to_region = yaml.safe_load(ip_to_region_file.read_text()) or {}
+    assert ip_to_region[test_ip] == expected_region
+
+
+@pytest.mark.ai_generated
 def test_refresh_ip_to_region_codes_handles_ipinfo_quota_exceeded(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_ip_utils.py
+++ b/tests/test_ip_utils.py
@@ -4,6 +4,7 @@ import shutil
 import unittest.mock
 
 import ipinfo
+import opencage.geocoder
 import py
 import pytest
 import yaml
@@ -165,10 +166,10 @@ def test_update_ip_to_region_codes_handles_ipinfo_quota_exceeded(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """update_ip_to_region_codes stores ``undetermined`` when IPInfo quota is exhausted."""
+    """update_ip_to_region_codes halts early on quota exhaustion and leaves unprocessed IPs uncached."""
     extraction_dir = tmp_path / "extraction" / "test_dataset" / "test_asset"
     extraction_dir.mkdir(parents=True)
-    test_ip = "4.4.4.4"
+    test_ip = "192.0.2.1"
     (extraction_dir / "ips.txt").write_text(test_ip)
 
     monkeypatch.setenv("IPINFO_API_KEY", "test-key-non-remote")
@@ -177,9 +178,117 @@ def test_update_ip_to_region_codes_handles_ipinfo_quota_exceeded(
     mock_handler.getDetails.side_effect = ipinfo.exceptions.RequestQuotaExceededError()
 
     with unittest.mock.patch("ipinfo.getHandler", return_value=mock_handler):
-        with pytest.warns(RuntimeWarning, match="IPInfo API request quota exceeded"):
-            s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
+        with unittest.mock.patch(
+            "s3_log_extraction.ip_utils._update_ip_to_region_codes._get_cidr_address_ranges_and_subregions",
+            return_value=[],
+        ):
+            with pytest.warns(RuntimeWarning, match="IPInfo API request quota exceeded"):
+                s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
+
+    # Only one request should have been attempted; the rest of the run is skipped
+    assert mock_handler.getDetails.call_count == 1
+
+    # The IP must not be cached (e.g., as "undetermined") so that it is retried on the next run
+    ip_to_region_file = tmp_path / "ips" / "ip_to_region.yaml"
+    ip_to_region = yaml.safe_load(ip_to_region_file.read_text()) if ip_to_region_file.exists() else {}
+    assert test_ip not in (ip_to_region or {})
+
+
+@pytest.mark.ai_generated
+def test_update_ip_to_region_codes_saves_progress_before_quota_exceeded(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IPs resolved before the quota is exhausted are kept in the cache."""
+    extraction_dir = tmp_path / "extraction" / "test_dataset" / "test_asset"
+    extraction_dir.mkdir(parents=True)
+    test_ips = ["192.0.2.1", "192.0.2.2"]
+    (extraction_dir / "ips.txt").write_text("\n".join(test_ips))
+
+    monkeypatch.setenv("IPINFO_API_KEY", "test-key-non-remote")
+
+    success_details = unittest.mock.MagicMock()
+    success_details.details = {"country": "US", "region": "California"}
+
+    mock_handler = unittest.mock.MagicMock()
+    mock_handler.getDetails.side_effect = [success_details, ipinfo.exceptions.RequestQuotaExceededError()]
+
+    with unittest.mock.patch("ipinfo.getHandler", return_value=mock_handler):
+        with unittest.mock.patch(
+            "s3_log_extraction.ip_utils._update_ip_to_region_codes._get_cidr_address_ranges_and_subregions",
+            return_value=[],
+        ):
+            with pytest.warns(RuntimeWarning, match="IPInfo API request quota exceeded"):
+                s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
 
     ip_to_region_file = tmp_path / "ips" / "ip_to_region.yaml"
     ip_to_region = yaml.safe_load(ip_to_region_file.read_text()) or {}
-    assert ip_to_region[test_ip] == "undetermined"
+    assert len(ip_to_region) == 1
+    assert next(iter(ip_to_region.values())) == "US/California"
+
+
+@pytest.mark.ai_generated
+def test_refresh_ip_to_region_codes_handles_ipinfo_quota_exceeded(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """refresh_ip_to_region_codes halts early on quota exhaustion without overwriting existing entries."""
+    test_ips_dir = tmp_path / "ips"
+    test_ips_dir.mkdir(parents=True)
+
+    initial_ip_to_region = {"192.0.2.1": "US/California"}
+    ip_to_region_file = test_ips_dir / "ip_to_region.yaml"
+    ip_to_region_file.write_text(yaml.dump(initial_ip_to_region))
+
+    monkeypatch.setenv("IPINFO_API_KEY", "test-key-non-remote")
+
+    fixed_ordinal_base = datetime.date(2000, 1, 1).toordinal()
+    offset = (-fixed_ordinal_base) % 90
+    fixed_date = datetime.date.fromordinal(fixed_ordinal_base + offset)
+
+    def mock_raise_quota_exceeded(ip_address: str, ipinfo_handler: object) -> str:
+        raise ipinfo.exceptions.RequestQuotaExceededError()
+
+    with unittest.mock.patch(
+        "s3_log_extraction.ip_utils._refresh_ip_to_region_codes._get_region_code_from_ip_address",
+        mock_raise_quota_exceeded,
+    ):
+        with unittest.mock.patch("ipinfo.getHandler"):
+            with pytest.warns(RuntimeWarning, match="IPInfo API request quota exceeded"):
+                s3_log_extraction.ip_utils.refresh_ip_to_region_codes(
+                    cache_directory=tmp_path,
+                    use_encryption=False,
+                    _today=fixed_date,
+                )
+
+    # Existing cache entries must remain untouched
+    updated_ip_to_region = yaml.safe_load(ip_to_region_file.read_text()) or {}
+    assert updated_ip_to_region == initial_ip_to_region
+
+
+@pytest.mark.ai_generated
+def test_update_region_code_coordinates_handles_ipinfo_quota_exceeded(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """update_region_code_coordinates saves partial progress instead of crashing when the quota is exhausted."""
+    test_ips_dir = tmp_path / "ips"
+    test_ips_dir.mkdir(parents=True)
+    (test_ips_dir / "ip_to_region.yaml").write_text(yaml.dump({"192.0.2.1": "US/California"}))
+
+    monkeypatch.setenv("IPINFO_API_KEY", "test-key-non-remote")
+    monkeypatch.setenv("OPENCAGE_API_KEY", "test-key-non-remote")
+
+    mock_geocoder = unittest.mock.MagicMock()
+    mock_geocoder.geocode.side_effect = opencage.geocoder.RateLimitExceededError()
+
+    with unittest.mock.patch("opencage.geocoder.OpenCageGeocode", return_value=mock_geocoder):
+        with unittest.mock.patch("ipinfo.getHandler"):
+            with pytest.warns(RuntimeWarning, match="quota exceeded"):
+                s3_log_extraction.ip_utils.update_region_code_coordinates(
+                    cache_directory=tmp_path, use_encryption=False
+                )
+
+    # The run must complete and write the (partial) coordinates cache
+    coordinates_file = test_ips_dir / "region_codes_to_coordinates.yaml"
+    assert coordinates_file.exists()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -8,6 +8,7 @@ remote-testing CI workflow, which supplies valid ``IPINFO_API_KEY`` and
 
 import os
 import pathlib
+import warnings
 
 import pytest
 import yaml
@@ -21,6 +22,17 @@ def _is_auth_error(exc: Exception) -> bool:
     """Return True if *exc* looks like an API authentication/authorization failure."""
     exc_str = str(exc).lower()
     return any(pattern.lower() in exc_str for pattern in _AUTH_ERROR_PATTERNS)
+
+
+def _skip_if_quota_exceeded(captured_warnings: list[warnings.WarningMessage]) -> None:
+    """Skip the current test if a quota-exceeded warning was emitted during the update call.
+
+    The update functions halt early with a ``RuntimeWarning`` when an API quota is exhausted.
+    That is an expected transient state of the shared API accounts, not a code or token failure,
+    so the live-lookup assertions cannot be validated and the test is skipped.
+    """
+    if any("quota exceeded" in str(captured_warning.message).lower() for captured_warning in captured_warnings):
+        pytest.skip("API request quota is currently exhausted; cannot validate live lookups.")
 
 
 @pytest.mark.remote
@@ -48,16 +60,19 @@ def test_update_ip_to_region_codes_remote(tmp_path: pathlib.Path) -> None:
     extraction_dir.mkdir(parents=True)
     (extraction_dir / "ips.txt").write_text(test_ip)
 
-    try:
-        s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
-    except Exception as exc:
-        if _is_auth_error(exc):
-            pytest.fail(
-                f"IPINFO_API_KEY is set but the token was rejected by the IPInfo API ({exc}). "
-                "Please verify that the IPINFO_API_KEY GitHub secret contains a valid token "
-                "from https://ipinfo.io/account/token"
-            )
-        raise
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        try:
+            s3_log_extraction.ip_utils.update_ip_to_region_codes(cache_directory=tmp_path, use_encryption=False)
+        except Exception as exc:
+            if _is_auth_error(exc):
+                pytest.fail(
+                    f"IPINFO_API_KEY is set but the token was rejected by the IPInfo API ({exc}). "
+                    "Please verify that the IPINFO_API_KEY GitHub secret contains a valid token "
+                    "from https://ipinfo.io/account/token"
+                )
+            raise
+    _skip_if_quota_exceeded(captured_warnings)
 
     ip_cache_dir = tmp_path / "ips"
     ip_to_region_file = ip_cache_dir / "ip_to_region.yaml"
@@ -98,16 +113,19 @@ def test_update_region_code_coordinates_remote(tmp_path: pathlib.Path) -> None:
     ip_to_region_file = ip_cache_dir / "ip_to_region.yaml"
     ip_to_region_file.write_text(yaml.dump({"4.4.4.4": region_code}))
 
-    try:
-        s3_log_extraction.ip_utils.update_region_code_coordinates(cache_directory=tmp_path, use_encryption=False)
-    except Exception as exc:
-        if _is_auth_error(exc):
-            pytest.fail(
-                f"OPENCAGE_API_KEY is set but was rejected by the OpenCage API ({exc}). "
-                "Please verify that the OPENCAGE_API_KEY GitHub secret contains a valid key "
-                "from https://opencagedata.com/dashboard#api-keys"
-            )
-        raise
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always")
+        try:
+            s3_log_extraction.ip_utils.update_region_code_coordinates(cache_directory=tmp_path, use_encryption=False)
+        except Exception as exc:
+            if _is_auth_error(exc):
+                pytest.fail(
+                    f"OPENCAGE_API_KEY is set but was rejected by the OpenCage API ({exc}). "
+                    "Please verify that the OPENCAGE_API_KEY GitHub secret contains a valid key "
+                    "from https://opencagedata.com/dashboard#api-keys"
+                )
+            raise
+    _skip_if_quota_exceeded(captured_warnings)
 
     coordinates_file = ip_cache_dir / "region_codes_to_coordinates.yaml"
     assert coordinates_file.exists(), "region_codes_to_coordinates.yaml was not created"


### PR DESCRIPTION
## Summary

This PR fixes the IP cache update workflows to handle API quota exhaustion gracefully instead of wasting resources on doomed requests or crashing. When IPInfo or OpenCage API quotas are exceeded, the affected functions now halt early and preserve partial progress rather than permanently caching failed lookups or raising unhandled exceptions.

## Key Changes

- **`update_ip_to_region_codes`**: Now catches `RequestQuotaExceededError` and halts early, leaving unprocessed IPs uncached so they can be retried on the next run (instead of permanently caching them as `"undetermined"`)

- **`refresh_ip_to_region_codes`**: Now catches `RequestQuotaExceededError` and halts early without overwriting existing cache entries when quota is exhausted

- **`update_region_code_coordinates`**: Now catches both `RequestQuotaExceededError` and `RateLimitExceededError`, saves partial progress, and exits cleanly instead of raising an unhandled exception

- **`_get_region_code_from_ip_address`**: Simplified to propagate `RequestQuotaExceededError` to the caller rather than catching it internally and returning `"undetermined"`. Updated return type to reflect that `None` can be returned instead of `"undetermined"`

## Implementation Details

- All three functions now use try-except blocks at the iteration level to catch quota errors and `break` early
- Each function emits a `RuntimeWarning` with a descriptive message when quota is exceeded
- The IP cache is written incrementally during processing, so partial progress is automatically preserved when a quota error occurs
- Test coverage added for all three scenarios with new test cases marked as `@pytest.mark.ai_generated`

https://claude.ai/code/session_01Bzr8gPQGtr6MyGucCkLGSU